### PR TITLE
Fetch fallback for ending user presence

### DIFF
--- a/src/_generated/constants.ts
+++ b/src/_generated/constants.ts
@@ -93,6 +93,6 @@ export const STAT_TYPE = {
 } as const;
 
 export const GAMEPLAY_HEARTBEAT = {
-	INTERVAL_MS: 30_000, // send heartbeat to backend every 30s
-	TIMEOUT_MS: 90_000 // mark user as disconnected after 90s of no heartbeats
+	INTERVAL_MS: 30_000,	// send heartbeat to backend every 30s
+	TIMEOUT_MS: 90_000		// mark user as disconnected after 90s of no heartbeats
 } as const;

--- a/src/services/heartbeat.ts
+++ b/src/services/heartbeat.ts
@@ -37,7 +37,15 @@ export class HeartbeatManager {
     if (typeof window !== 'undefined' && this.convexHttpOrigin) {
       window.addEventListener('pagehide', (event) => {
         // Send a beacon POST request to the backend to end user presence
-        navigator.sendBeacon(`${this.convexHttpOrigin}/webhooks/end-user-presence`);
+        const url = `${this.convexHttpOrigin}/webhooks/end-user-presence`;
+        const sent = navigator.sendBeacon(url);
+        if (!sent) {
+          fetch(url, {
+            method: 'POST',
+            keepalive: true,
+            credentials: 'include'
+          });
+        }
       }, { capture: true });
     }
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add a POST fetch (keepalive, include credentials) fallback on pagehide if sendBeacon fails to end user presence.
> 
> - **Heartbeat service (`src/services/heartbeat.ts`)**:
>   - On `pagehide`, attempt `navigator.sendBeacon` to `.../webhooks/end-user-presence`; if it returns false, fallback to `fetch` with `POST`, `keepalive: true`, and `credentials: 'include'`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d24ef0f6f5e5892fdcbc437268e4ae3804e2a0c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->