### PR TITLE
Make loadScript await async entrypoint scripts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1003,16 +1003,18 @@ class WavedashSDK extends EventTarget {
   // ============
   // Entrypoint Helpers
   // ============
-  loadScript(src: string) {
-    return new Promise((resolve, reject) => {
-      const script = document.createElement("script");
-      script.type = "text/javascript";
-      script.src = src;
-      script.crossOrigin = "use-credentials"; // Enable CORS with credentials (cookies, auth)
-      script.onload = resolve;
-      script.onerror = reject;
-      document.head.appendChild(script);
-    });
+  async loadScript(src: string) {
+    const response = await fetch(src, { credentials: "include" });
+    if (!response.ok) {
+      throw new Error(`Failed to load script: ${src} (${response.status})`);
+    }
+    const text = await response.text();
+    // Use indirect eval so the script executes in global scope
+    const result = (0, eval)(text);
+    // If the script returns a Promise (e.g. async IIFE), await it
+    if (result && typeof result.then === "function") {
+      await result;
+    }
   }
 
   updateLoadProgressZeroToOne(progress: number) {


### PR DESCRIPTION
## Summary
- `loadScript()` used a `<script>` tag whose `onload` fires when the script is parsed, not when async work inside it completes. This caused race conditions where engine entrypoints would start the game before the loader script's async operations (cloud save downloads, etc.) had finished.
- Switch to `fetch()` + indirect `eval()` so we can capture the script's return value. If it returns a Promise (e.g. from an async IIFE), we await it before resolving.
- This means `await loadScript('entrypoint.js')` now properly waits for the entrypoint's async work to complete — no game-side polling or `window._entrypointReady` hacks needed.

### Before
```js
// entrypoint.js — async IIFE
(async function() {
  await downloadCloudSave(); // takes time
})();
// loadScript resolves HERE (script parsed) — cloud save still downloading
// engine starts immediately — race condition!
```

### After
```js
// Same entrypoint.js — no changes needed
(async function() {
  await downloadCloudSave();
})();
// loadScript now awaits the returned Promise — cloud save ready
// engine starts after — no race condition
```

## Test plan
- [ ] Ruffle game with async `loader_url` entrypoint: cloud save ready before SWF starts
- [ ] js-dos game with async `dosOptions` entrypoint: still works (returns Promise, now properly awaited)
- [ ] Godot/Unity games with synchronous loader scripts: still work (no Promise returned, no await)
- [ ] Script load errors: rejected Promise surfaces correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)