### PR TITLE
Change loadScript crossOrigin to anonymous

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1008,7 +1008,7 @@ class WavedashSDK extends EventTarget {
       const script = document.createElement("script");
       script.type = "text/javascript";
       script.src = src;
-      script.crossOrigin = "use-credentials"; // Enable CORS with credentials (cookies, auth)
+      script.crossOrigin = "anonymous";
       script.onload = resolve;
       script.onerror = reject;
       document.head.appendChild(script);


### PR DESCRIPTION
## Summary
- Change `script.crossOrigin` from `"use-credentials"` to `"anonymous"` in `loadScript()`
- Scripts loaded are static assets (engine runtimes, developer entrypoints) that don't need cookies
- `use-credentials` causes CORS failures when loading from cross-origin static hosts (e.g. R2 buckets)

## Context
Needed for wvdsh/play#47 which moves engine runtimes to R2 static buckets served cross-origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)