### PR TITLE
Deprecate getUsername()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -288,6 +288,7 @@ class WavedashSDK extends EventTarget {
     return this.formatResponse(this.wavedashUser);
   }
 
+  /** @deprecated Use `getUser().username` instead */
   getUsername(): string {
     this.ensureReady();
     return this.wavedashUser.username;


### PR DESCRIPTION
## Summary
- Mark `getUsername()` as `@deprecated` in favor of `getUser().username`
- The method was bundled in with the remote storage API (2025-09-02) and isn't documented or used internally

🤖 Generated with [Claude Code](https://claude.com/claude-code)