### PR TITLE
Let SDK handle all iframe messaging

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -950,6 +950,8 @@ export async function setupWavedashSDK(): Promise<WavedashSDK> {
     .WavedashJS;
   if (existing) return existing;
 
+  iframeMessenger.registerEventHandlers();
+
   const sdkConfig = await iframeMessenger.requestFromParent(
     IFRAME_MESSAGE_TYPE.GET_SDK_CONFIG
   );
@@ -960,3 +962,4 @@ export async function setupWavedashSDK(): Promise<WavedashSDK> {
 
   return sdk;
 }
+

--- a/src/utils/iframeMessenger.ts
+++ b/src/utils/iframeMessenger.ts
@@ -66,6 +66,37 @@ export class IFrameMessenger {
     return true;
   }
 
+  /**
+   * Register global keyboard/mouse handlers for iframe communication.
+   * Handles F3 prevention, initial interaction signaling, and Tab+Shift overlay toggle.
+   * Called once during SDK setup.
+   */
+  registerEventHandlers() {
+    let sentInitialInteraction = false;
+
+    const handleInteraction = () => {
+      if (!sentInitialInteraction) {
+        sentInitialInteraction = true;
+        this.postToParent(IFRAME_MESSAGE_TYPE.INITIAL_INTERACTION, {});
+      }
+    };
+
+    window.addEventListener("keydown", (event) => {
+      if (event.key === "F3") {
+        event.preventDefault();
+      }
+
+      handleInteraction();
+
+      if (event.key === "Tab" && event.shiftKey) {
+        event.preventDefault();
+        this.postToParent(IFRAME_MESSAGE_TYPE.TOGGLE_OVERLAY, {});
+      }
+    });
+
+    window.addEventListener("mousedown", handleInteraction);
+  }
+
   async requestFromParent<T extends keyof IFrameResponseMap>(
     requestType: T,
     data?: Record<string, unknown>


### PR DESCRIPTION
Play ServiceWorker was handling some if its own iframe messaging with the parent for things like overlay toggle and F3 prevention
Let SDK handle all of that since it already owns iframe messaging setup and mid game iframe messages