### PR TITLE
getUsername can return any username by ID that the game has seen so far

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -239,8 +239,19 @@ class WavedashSDK extends EventTarget {
     return this.formatResponse(this.wavedashUser);
   }
 
-  getUsername(): string {
-    return this.wavedashUser.username;
+  /**
+   * Get a username. Returns the logged in user's username if no ID is passed.
+   * This can only return a username for a user the game has already interacted with, either via listFriends() or shared lobby membership.
+   * @param userId - Optional user ID to look up. If omitted, returns the current user's username.
+   * @returns The username, or null if a userId was passed but the user has not been seen by the game yet.
+   */
+  getUsername(): string;
+  getUsername(userId: Id<"users">): string | null;
+  getUsername(userId?: Id<"users">): string | null {
+    if (userId === undefined) {
+      return this.wavedashUser.username;
+    }
+    return this.friendsManager.getUsername(userId);
   }
 
   getUserId(): Id<"users"> {

--- a/src/services/friends.ts
+++ b/src/services/friends.ts
@@ -76,6 +76,15 @@ export class FriendsManager {
     });
   }
 
+  /**
+   * Returns the cached username for a given user ID
+   * @param userId - The user ID to get the username for
+   * @returns The username, or null if user not cached
+   */
+  getUsername(userId: Id<"users">): string | null {
+    return this.userCache.get(userId)?.username ?? null;
+  }
+
   async listFriends(): Promise<Friend[]> {
     const friends = await this.sdk.convexClient.query(
       api.sdk.friends.listFriends,


### PR DESCRIPTION
If you get a friends list or join a lobby, you should be able to call `getUsername` for any of those IDs so you don't need to re-iterate through the list