### PR TITLE
fix: throw an error on lobby full (enforce the currently unenforced `maxPeers` config param)

### DIFF
--- a/src/services/p2p.ts
+++ b/src/services/p2p.ts
@@ -237,6 +237,8 @@ export class P2PManager {
     lobbyId: Id<"lobbies">,
     members: SDKUser[]
   ): Promise<P2PConnection> {
+    this.validatePeerLimit(members);
+
     const connection: P2PConnection = {
       lobbyId,
       peers: {},
@@ -297,9 +299,12 @@ export class P2PManager {
   private async updateP2PConnection(
     members: SDKUser[]
   ): Promise<P2PConnection> {
+
     if (!this.currentConnection) {
       throw new Error("No existing P2P connection to update");
     }
+
+    this.validatePeerLimit(members);
 
     this.sdk.logger.debug("Updating P2P connection with new member list");
 
@@ -702,6 +707,18 @@ export class P2PManager {
         }
       }
       this.pendingIceCandidates.delete(remoteUserId);
+    }
+  }
+
+  private validatePeerLimit(members: SDKUser[]): void {
+    const remotePeerCount = members.filter(
+      (member) => member.id !== this.sdk.getUserId()
+    ).length;
+  
+    if (remotePeerCount > this.config.maxPeers) {
+      throw new Error(
+        `P2P peer limit exceeded: lobby has ${remotePeerCount} remote peers, but maxPeers is ${this.config.maxPeers}`
+      );
     }
   }
 


### PR DESCRIPTION
This change enforces the existing `maxPeers` config param at runtime so that it functions as a real SDK limit rather than a documented but unused setting.

This treats a connection above the max as a lobby-wide invalid-state check rather than selective lobby admission denial for only that newest joiner that exceeded the limit. That means an oversized lobby is an error for all clients processing that membership update. Maybe this is undesired, IDK!
