### PR TITLE
Remove unused maxPeers p2p config

### DIFF
--- a/src/services/p2p.ts
+++ b/src/services/p2p.ts
@@ -22,7 +22,6 @@ import { api, P2P_SIGNALING_MESSAGE_TYPE, SDKUser } from "@wvdsh/types";
 
 // Default P2P configuration
 const DEFAULT_P2P_CONFIG: Required<P2PConfig> = {
-  maxPeers: 8,
   enableReliableChannel: true,
   enableUnreliableChannel: true,
   messageSize: 2048,

--- a/src/types.ts
+++ b/src/types.ts
@@ -235,7 +235,6 @@ export interface P2PMessage {
 
 // P2P Configuration
 export interface P2PConfig {
-  maxPeers: number;
   enableReliableChannel: boolean;
   enableUnreliableChannel: boolean;
   messageSize?: number; // Max bytes per message slot. Default: 2048. Must be > 44, capped at 65536.


### PR DESCRIPTION
Already handled by lobby maxPlayers
Devs are free to push the bandwidth limits and see how many lobby players their game can handle.
WebRTC connections isn't the bottleneck for the game, upload bandwidth is