### PR TITLE
Gameplay Token comes from Own Origin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@wvdsh/sdk-js",
       "version": "1.3.1",
       "dependencies": {
-        "@wvdsh/api": "^0.1.3",
+        "@wvdsh/api": "^0.1.9",
         "convex": "^1.34.0",
         "lodash.debounce": "^4.0.8"
       },
@@ -1101,7 +1101,6 @@
       "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
         "@typescript-eslint/types": "8.52.0",
@@ -1314,9 +1313,9 @@
       }
     },
     "node_modules/@wvdsh/api": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@wvdsh/api/-/api-0.1.3.tgz",
-      "integrity": "sha512-14qeegN0t79TNhFEK4EjbQaJhKZoOMG+9niVe1tWJdyuiUVaY+eqUAYHd211hQnWZBY+RKAjqdf0AZG1blQaPQ==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@wvdsh/api/-/api-0.1.9.tgz",
+      "integrity": "sha512-N9S4F+KYjQJ76LSG5VB0MnlTj5AYk0D2s6s5ieFi+yqRMmxjCTrmP+eLNvz7dqbMMeFKqUxP0so/0OVTxnHuBA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -1331,7 +1330,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1542,7 +1540,6 @@
       "resolved": "https://registry.npmjs.org/convex/-/convex-1.36.1.tgz",
       "integrity": "sha512-NVnwNqU+h8jyPuS0Itvj4MPH9c2yF+tA/RNoSDpCqiLhmYD4+kZxm0dDkVM0QDzz66wem9NqheBb9YQGsHwzBQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "esbuild": "0.27.0",
         "prettier": "^3.0.0",
@@ -1692,7 +1689,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2389,7 +2385,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3277,7 +3272,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "typescript-eslint": "^8.52.0"
   },
   "dependencies": {
-    "@wvdsh/api": "^0.1.3",
+    "@wvdsh/api": "^0.1.9",
     "convex": "^1.34.0",
     "lodash.debounce": "^4.0.8"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ import type {
   GameLaunchParams
 } from "./types";
 import { IFRAME_MESSAGE_TYPE, SDKConfig, SDKUser, UrlParams } from "@wvdsh/api";
-import { parentOrigin } from "./utils/parentOrigin";
+import { setParentOrigin } from "./utils/parentOrigin";
 import {
   type ArgSpec,
   validateArgs,
@@ -1291,8 +1291,12 @@ class WavedashSDK extends EventTarget {
    * fetcher wired into `ConvexClient.setAuth` and honors `forceRefresh` so the
    * server can invalidate a stale token.
    *
+   * Same-origin POST to /auth/refresh on the play domain — the
+   * gameplaySession cookie set by the play server during playKey exchange
+   * authenticates the request, so no cross-origin credentials handling needed.
+   *
    * Concurrent callers share a single in-flight fetch to avoid duplicate
-   * requests to the parent's gameplay-token endpoint.
+   * refresh round-trips.
    */
   private getAuthToken(forceRefresh = false): Promise<string> {
     if (!forceRefresh && this.gameplayJwt) {
@@ -1303,14 +1307,12 @@ class WavedashSDK extends EventTarget {
     }
 
     const promise = (async () => {
-      const response = await fetch(
-        `${parentOrigin}/auth/gameplay_token/${this.gameCloudId}`,
-        {
-          credentials: "include"
-        }
-      );
+      const response = await fetch("/auth/refresh", {
+        method: "POST",
+        credentials: "same-origin"
+      });
       if (!response.ok) {
-        throw new Error(`Failed to fetch gameplay token: ${response.status}`);
+        throw new Error(`Failed to refresh gameplay token: ${response.status}`);
       }
       this.gameplayJwt = await response.text();
       return this.gameplayJwt;
@@ -1424,6 +1426,11 @@ export function setupWavedashSDK(): WavedashSDK {
       `Wavedash SDK: failed to parse ?${UrlParams.SdkConfig}= as JSON: ${message}`
     );
   }
+
+  // iframeMessenger reads parent origin via getParentOrigin(); set before
+  // constructing the SDK so any postMessage handlers wired in the constructor
+  // see the right value.
+  setParentOrigin(sdkConfig.parentOrigin);
 
   const sdk = new WavedashSDK(sdkConfig);
   window.Wavedash = sdk;

--- a/src/utils/iframeMessenger.ts
+++ b/src/utils/iframeMessenger.ts
@@ -6,7 +6,7 @@
  */
 
 import { IFRAME_MESSAGE_TYPE, IFrameEventPayloadMap } from "@wvdsh/api";
-import { parentOrigin } from "./parentOrigin";
+import { getParentOrigin } from "./parentOrigin";
 
 const RESPONSE_TIMEOUT_MS = 15_000;
 
@@ -68,7 +68,7 @@ export class IFrameMessenger {
   private handleMessage = (event: MessageEvent): void => {
     // Validate origin to prevent JWT spoofing and other attacks.
     // Skip messages from our own window (e.g. js-dos sleep-sync postMessage traffic).
-    if (event.origin !== parentOrigin) {
+    if (event.origin !== getParentOrigin()) {
       if (event.source !== window) {
         console.warn(`Ignored message from untrusted origin: ${event.origin}`);
       }
@@ -97,6 +97,7 @@ export class IFrameMessenger {
     requestType: (typeof IFRAME_MESSAGE_TYPE)[keyof typeof IFRAME_MESSAGE_TYPE],
     data: Record<string, string | number | boolean>
   ): boolean {
+    const parentOrigin = getParentOrigin();
     if (typeof window === "undefined" || !parentOrigin) return false;
     window.parent.postMessage({ type: requestType, ...data }, parentOrigin);
     return true;
@@ -107,6 +108,7 @@ export class IFrameMessenger {
     data?: Record<string, unknown>
   ): Promise<IFrameEventPayloadMap[T]> {
     return new Promise((resolve, reject) => {
+      const parentOrigin = getParentOrigin();
       if (typeof window === "undefined" || !parentOrigin) {
         reject(new Error("Parent origin not found"));
         return;

--- a/src/utils/parentOrigin.ts
+++ b/src/utils/parentOrigin.ts
@@ -1,18 +1,16 @@
 /**
- * Derive parent origin from iframe URL pattern.
- * iframe: [gameSlug].(builds|sandbox|local).[parentDomain]
- * parent: [parentDomain]
+ * Parent (mainsite) origin used by iframeMessenger for postMessage targeting
+ * and incoming-message origin validation. Set once from SDKConfig.parentOrigin
+ * during setupWavedashSDK() bootstrap — must be passed explicitly because the
+ * play iframe can live on a different TLD than the mainsite, so it can't be
+ * derived from the iframe hostname.
  */
-function deriveParentOrigin(): string {
-  if (typeof window === "undefined") return "";
-  const iframeHost = window.location.host;
-  const match = iframeHost.match(/^[\w-]+\.(builds|local)\.(.+)$/);
-  if (match) {
-    const parentDomain = match[2];
-    return `${window.location.protocol}//${parentDomain}`;
-  }
-  console.error(`Invalid iframe hostname pattern: ${iframeHost}`);
-  return "";
+let _parentOrigin = "";
+
+export function setParentOrigin(origin: string): void {
+  _parentOrigin = origin;
 }
 
-export const parentOrigin = deriveParentOrigin();
+export function getParentOrigin(): string {
+  return _parentOrigin;
+}


### PR DESCRIPTION
Fetch and refresh gameplayJwt from SDK's own origin
Lets game run on a fully separate domain from wavedash.com
Parent origin now passed in via SDK config rather than attempting to deduce based on own origin