### PR TITLE
Parent Handles end-session

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@wvdsh/sdk-js",
       "version": "1.3.3",
       "dependencies": {
-        "@wvdsh/api": "^0.1.10",
+        "@wvdsh/api": "^0.1.11",
         "convex": "^1.34.0",
         "lodash.debounce": "^4.0.8"
       },
@@ -1313,9 +1313,9 @@
       }
     },
     "node_modules/@wvdsh/api": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/@wvdsh/api/-/api-0.1.10.tgz",
-      "integrity": "sha512-hItQ8C3boxyoJFbL48HlJ2hmttuUU0DvlXjTUb1OaKQ1iNrDskSgFrQSYO7mXi9CtFVYHuLF9/twr6xxqisf4Q==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@wvdsh/api/-/api-0.1.11.tgz",
+      "integrity": "sha512-DUeCsSddHQYuiVBNhHPrhwIzgavJK4TL8+LTTvOQBdA/ZY3md68b7WUmNbRjmrRaTIvBTP6uDdS8g+g6zznPyQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wvdsh/sdk-js",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "type": "module",
   "description": "Wavedash JavaScript SDK",
   "main": "./dist/client.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wvdsh/sdk-js",
-  "version": "1.3.4",
+  "version": "1.3.3",
   "type": "module",
   "description": "Wavedash JavaScript SDK",
   "main": "./dist/client.js",
@@ -49,7 +49,7 @@
     "typescript-eslint": "^8.52.0"
   },
   "dependencies": {
-    "@wvdsh/api": "^0.1.10",
+    "@wvdsh/api": "^0.1.11",
     "convex": "^1.34.0",
     "lodash.debounce": "^4.0.8"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,17 +28,6 @@ import { WavedashEvents } from "./events";
 import type { WavedashEventMap } from "./types";
 import type { WavedashManager } from "./services/manager";
 
-type WavedashService =
-  | LobbyManager
-  | FileSystemManager
-  | UGCManager
-  | LeaderboardManager
-  | P2PManager
-  | HeartbeatManager
-  | FriendsManager
-  | StatsManager
-  | FullscreenManager;
-
 // Create singleton instance for iframe messaging
 const iframeMessenger = new IFrameMessenger();
 
@@ -1249,7 +1238,7 @@ class WavedashSDK extends EventTarget {
     }
   }
 
-  private async apiCall<T extends WavedashService, K extends string & keyof T>(
+  private async apiCall<T extends WavedashManager, K extends string & keyof T>(
     manager: T,
     method: K,
     argSpecs: readonly ArgSpec[],
@@ -1267,7 +1256,7 @@ class WavedashSDK extends EventTarget {
     }
   }
 
-  private apiCallSync<T extends WavedashService, K extends string & keyof T>(
+  private apiCallSync<T extends WavedashManager, K extends string & keyof T>(
     target: T,
     method: K,
     argSpecs: readonly ArgSpec[],

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import {
 } from "./constants";
 import { WavedashEvents } from "./events";
 import type { WavedashEventMap } from "./types";
+import type { WavedashManager } from "./services/manager";
 
 type WavedashService =
   | LobbyManager
@@ -91,7 +92,7 @@ class WavedashSDK extends EventTarget {
     return this._eventsReady;
   }
   private launchParams: GameLaunchParams;
-  private sessionEndSent: boolean = false;
+  private destroyed: boolean = false;
   private gameFinishedLoading: boolean = false;
 
   // Expose constants for easy access `Wavedash.LobbyVisibility.PUBLIC` etc.
@@ -126,6 +127,7 @@ class WavedashSDK extends EventTarget {
   p2pManager: P2PManager;
   fullscreenManager: FullscreenManager;
   overlayManager: OverlayManager;
+  private managers: WavedashManager[];
   private gameplayJwt: string | null = null;
   private gameplayJwtPromise: Promise<string> | null = null;
   private setupWarningTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -157,6 +159,23 @@ class WavedashSDK extends EventTarget {
     this.gameEventManager = new GameEventManager(this);
     this.fullscreenManager = new FullscreenManager(this);
     this.overlayManager = new OverlayManager(this);
+
+    // Single source of truth for teardown — `destroy()` iterates this list.
+    // Order matches construction so destroys happen in dependency order
+    // (e.g. lobby's destroy may want p2p, but lobby is created after p2p).
+    this.managers = [
+      this.p2pManager,
+      this.lobbyManager,
+      this.statsManager,
+      this.heartbeatManager,
+      this.fileSystemManager,
+      this.ugcManager,
+      this.leaderboardManager,
+      this.friendsManager,
+      this.gameEventManager,
+      this.fullscreenManager,
+      this.overlayManager
+    ];
 
     // Cache current user for avatar lookups
     this.friendsManager.cacheUsers([
@@ -1340,29 +1359,22 @@ class WavedashSDK extends EventTarget {
   }
 
   /**
-   * Listen for the parent's `END_SESSION` signal and tear down client-side
-   * state (lobby/heartbeat/stats subscriptions). The parent fires the actual
-   * /end-session HTTP request itself (using the JWT we pushed to it via
-   * GAMEPLAY_JWT_READY) — iframe-originated requests get cancelled when the
-   * iframe is detached, but parent-originated keepalive fetches survive.
-   *
-   * The parent only posts END_SESSION on committed leaves (its own pagehide
-   * after the user accepts the leave dialog, or SvelteKit beforeNavigate on
-   * SPA route change), so cancelling the "Leave site?" dialog leaves the
-   * SDK and its Convex subscriptions intact.
+   * Tear down every manager. Called on the parent's `END_SESSION` signal
+   * (committed leaves only — see GameRunnerComponent.svelte). Idempotent.
+   * Each manager's `destroy()` defaults to a no-op; managers with ongoing
+   * state (subscriptions, intervals, peer connections) override it.
    */
-  private setupSessionEndListeners(): void {
-    const endGameplaySession = () => {
-      if (this.sessionEndSent) return;
-      this.sessionEndSent = true;
-      this.lobbyManager.destroy();
-      this.heartbeatManager.destroy();
-      this.statsManager.destroy();
-    };
+  private destroy(): void {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    for (const manager of this.managers) {
+      manager.destroy();
+    }
+  }
 
-    iframeMessenger.addEventListener(
-      IFRAME_MESSAGE_TYPE.END_SESSION,
-      endGameplaySession
+  private setupSessionEndListeners(): void {
+    iframeMessenger.addEventListener(IFRAME_MESSAGE_TYPE.END_SESSION, () =>
+      this.destroy()
     );
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1337,10 +1337,16 @@ class WavedashSDK extends EventTarget {
 
   /**
    * Set up listeners that flush the end-of-session request when the iframe
-   * is going away. We listen for three signals:
-   *   - `beforeunload` / `pagehide` on our own window: covers tab close, hard
-   *     reload, and top-level navigation of the parent.
+   * is going away. We listen for two signals:
+   *   - `pagehide` on our own window: covers tab close, hard reload, and
+   *     top-level navigation of the parent.
    *   - `END_SESSION` postMessage from the parent: covers parent SPA navigation
+   *     that detaches the iframe element from the DOM (no unload event fires).
+   *
+   * We deliberately do NOT listen for `beforeunload`. `beforeunload` runs
+   * before the browser's "Leave site?" confirmation dialog — if we ran our
+   * teardown there and the user clicked Cancel, the session would already be
+   * marked ended on the server while the iframe stayed alive on the client.
    */
   private setupSessionEndListeners(): void {
     const endSessionEndpoint = `${this.convexHttpUrl}/gameplay/end-session`;
@@ -1382,7 +1388,6 @@ class WavedashSDK extends EventTarget {
       }
     };
 
-    window.addEventListener("beforeunload", endGameplaySession);
     window.addEventListener("pagehide", endGameplaySession);
     iframeMessenger.addEventListener(
       IFRAME_MESSAGE_TYPE.END_SESSION,

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,6 @@ class WavedashSDK extends EventTarget {
   }
   private launchParams: GameLaunchParams;
   private sessionEndSent: boolean = false;
-  private convexHttpUrl: string;
   private gameFinishedLoading: boolean = false;
 
   // Expose constants for easy access `Wavedash.LobbyVisibility.PUBLIC` etc.
@@ -142,7 +141,6 @@ class WavedashSDK extends EventTarget {
     this.convexClient.setAuth(({ forceRefreshToken }) =>
       this.getAuthToken(forceRefreshToken)
     );
-    this.convexHttpUrl = sdkConfig.convexHttpUrl;
     this.wavedashUser = sdkConfig.wavedashUser;
     this.iframeMessenger = iframeMessenger;
     this.ugcHost = sdkConfig.ugcHost;
@@ -1315,6 +1313,12 @@ class WavedashSDK extends EventTarget {
         throw new Error(`Failed to refresh gameplay token: ${response.status}`);
       }
       this.gameplayJwt = await response.text();
+      // Push the JWT to the parent so it can fire /end-session on its own
+      // pagehide / beforeNavigate. Parent-driven so the request originates
+      // from a context that won't be destroyed when the iframe is detached.
+      iframeMessenger.postToParent(IFRAME_MESSAGE_TYPE.GAMEPLAY_JWT_READY, {
+        gameplayJwt: this.gameplayJwt
+      });
       return this.gameplayJwt;
     })().finally(() => {
       if (this.gameplayJwtPromise === promise) {
@@ -1336,59 +1340,26 @@ class WavedashSDK extends EventTarget {
   }
 
   /**
-   * Set up listeners that flush the end-of-session request when the iframe
-   * is going away. We listen for two signals:
-   *   - `pagehide` on our own window: covers tab close, hard reload, and
-   *     top-level navigation of the parent.
-   *   - `END_SESSION` postMessage from the parent: covers parent SPA navigation
-   *     that detaches the iframe element from the DOM (no unload event fires).
+   * Listen for the parent's `END_SESSION` signal and tear down client-side
+   * state (lobby/heartbeat/stats subscriptions). The parent fires the actual
+   * /end-session HTTP request itself (using the JWT we pushed to it via
+   * GAMEPLAY_JWT_READY) — iframe-originated requests get cancelled when the
+   * iframe is detached, but parent-originated keepalive fetches survive.
    *
-   * We deliberately do NOT listen for `beforeunload`. `beforeunload` runs
-   * before the browser's "Leave site?" confirmation dialog — if we ran our
-   * teardown there and the user clicked Cancel, the session would already be
-   * marked ended on the server while the iframe stayed alive on the client.
+   * The parent only posts END_SESSION on committed leaves (its own pagehide
+   * after the user accepts the leave dialog, or SvelteKit beforeNavigate on
+   * SPA route change), so cancelling the "Leave site?" dialog leaves the
+   * SDK and its Convex subscriptions intact.
    */
   private setupSessionEndListeners(): void {
-    const endSessionEndpoint = `${this.convexHttpUrl}/gameplay/end-session`;
-
     const endGameplaySession = () => {
       if (this.sessionEndSent) return;
-      if (!this.gameplayJwt) return;
       this.sessionEndSent = true;
-
-      const pendingData = this.statsManager.getPendingData();
       this.lobbyManager.destroy();
       this.heartbeatManager.destroy();
       this.statsManager.destroy();
-
-      const body: Record<string, unknown> = {
-        gameplayJwt: this.gameplayJwt
-      };
-      if (pendingData?.stats?.length) {
-        body.stats = pendingData.stats;
-      }
-      if (pendingData?.achievements?.length) {
-        body.achievements = pendingData.achievements;
-      }
-
-      // sendBeacon with a string body uses Content-Type: text/plain;charset=UTF-8,
-      // which is a "simple" CORS request — no preflight, no Authorization
-      // header. The endpoint parses the body as JSON regardless of header.
-      const payload = JSON.stringify(body);
-      const beaconSent = navigator?.sendBeacon?.(endSessionEndpoint, payload);
-
-      if (!beaconSent) {
-        // Fallback for environments without sendBeacon. keepalive lets the
-        // request outlive the document; same simple-request shape as above.
-        fetch(endSessionEndpoint, {
-          method: "POST",
-          body: payload,
-          keepalive: true
-        }).catch(() => {});
-      }
     };
 
-    window.addEventListener("pagehide", endGameplaySession);
     iframeMessenger.addEventListener(
       IFRAME_MESSAGE_TYPE.END_SESSION,
       endGameplaySession

--- a/src/services/fileSystem.ts
+++ b/src/services/fileSystem.ts
@@ -9,6 +9,7 @@
 import type { RemoteFileMetadata } from "../types";
 import type { WavedashSDK } from "../index";
 import * as indexedDBUtils from "../utils/indexedDB";
+import { WavedashManager } from "./manager";
 import { api } from "@wvdsh/api";
 
 // Name of the remote R2 folder that stores user files
@@ -18,12 +19,11 @@ const REMOTE_STORAGE_FOLDER = "userfs";
 // Stable path used as the remote key prefix, replacing the per-build Unity persistentDataPath
 const WAVEDASH_PERSISTENT_DATA_PATH = "/idbfs/wavedash";
 
-export class FileSystemManager {
-  private sdk: WavedashSDK;
+export class FileSystemManager extends WavedashManager {
   private remoteStorageOrigin: string | undefined;
 
   constructor(sdk: WavedashSDK) {
-    this.sdk = sdk;
+    super(sdk);
   }
 
   /**

--- a/src/services/friends.ts
+++ b/src/services/friends.ts
@@ -9,18 +9,18 @@ import type { WavedashSDK } from "../index";
 import { api } from "@wvdsh/api";
 import { getCdnImageUrl } from "../utils/cdn";
 import { AvatarSize } from "../constants";
+import { WavedashManager } from "./manager";
 
 interface CachedUser {
   username: string;
   avatarR2Key?: string; // The r2Key (backend returns this as "avatarUrl")
 }
 
-export class FriendsManager {
-  private sdk: WavedashSDK;
+export class FriendsManager extends WavedashManager {
   private userCache: Map<Id<"users">, CachedUser> = new Map();
 
   constructor(sdk: WavedashSDK) {
-    this.sdk = sdk;
+    super(sdk);
   }
 
   /**

--- a/src/services/fullscreen.ts
+++ b/src/services/fullscreen.ts
@@ -2,6 +2,7 @@ import { IFRAME_MESSAGE_TYPE } from "@wvdsh/api";
 import type { WavedashSDK } from "../index";
 import { WavedashEvents } from "../events";
 import type { FullscreenChangedPayload } from "../types";
+import { WavedashManager } from "./manager";
 
 /**
  * FullscreenManager
@@ -22,13 +23,12 @@ import type { FullscreenChangedPayload } from "../types";
  * calls route through us. The iframe isn't granted the fullscreen feature
  * policy anymore, so without these shims those calls would silently reject.
  */
-export class FullscreenManager {
+export class FullscreenManager extends WavedashManager {
   private _isFullscreen = false;
   private listeners = new Set<(isFullscreen: boolean) => void>();
-  private sdk: WavedashSDK;
 
   constructor(sdk: WavedashSDK) {
-    this.sdk = sdk;
+    super(sdk);
     this.sdk.iframeMessenger.addEventListener(
       IFRAME_MESSAGE_TYPE.FULLSCREEN_CHANGED,
       (data) => {

--- a/src/services/gameEvents.ts
+++ b/src/services/gameEvents.ts
@@ -1,17 +1,17 @@
 import type { WavedashSDK } from "../index";
 import type { WavedashEvent } from "../types";
+import { WavedashManager } from "./manager";
 
 interface QueuedEvent {
   event: WavedashEvent;
   payload: string | number | object;
 }
 
-export class GameEventManager {
-  private sdk: WavedashSDK;
+export class GameEventManager extends WavedashManager {
   private eventQueue: QueuedEvent[] = [];
 
   constructor(sdk: WavedashSDK) {
-    this.sdk = sdk;
+    super(sdk);
   }
 
   // ==============================

--- a/src/services/heartbeat.ts
+++ b/src/services/heartbeat.ts
@@ -12,13 +12,13 @@ import {
   HEARTBEAT,
   IFRAME_MESSAGE_TYPE
 } from "@wvdsh/api";
-import type { WavedashSDK } from "../index";
 import { WavedashEvents } from "../events";
 import type { ConnectionState } from "convex/browser";
 import type { BackendConnectionPayload } from "../types";
+import { WavedashManager } from "./manager";
+import type { WavedashSDK } from "../index";
 
-export class HeartbeatManager {
-  private sdk: WavedashSDK;
+export class HeartbeatManager extends WavedashManager {
   private deviceFingerprint: DeviceFingerprint | undefined = undefined;
   // Resolves once the parent has answered the device fingerprint request
   // (or we've given up on it). Always resolves — never rejects. Best-effort:
@@ -38,7 +38,7 @@ export class HeartbeatManager {
   private readonly DISCONNECTED_TIMEOUT_MS = 90_000;
 
   constructor(sdk: WavedashSDK) {
-    this.sdk = sdk;
+    super(sdk);
 
     this.isConnected =
       this.sdk.convexClient.client.connectionState().isWebSocketConnected;

--- a/src/services/leaderboards.ts
+++ b/src/services/leaderboards.ts
@@ -14,15 +14,14 @@ import type {
 } from "../types";
 import type { WavedashSDK } from "../index";
 import { api } from "@wvdsh/api";
+import { WavedashManager } from "./manager";
 
-export class LeaderboardManager {
-  private sdk: WavedashSDK;
-
+export class LeaderboardManager extends WavedashManager {
   // Cache leaderboards to return totalEntries synchronously without a network call
   private leaderboardCache: Map<Id<"leaderboards">, Leaderboard> = new Map();
 
   constructor(sdk: WavedashSDK) {
-    this.sdk = sdk;
+    super(sdk);
   }
 
   async getLeaderboard(name: string): Promise<Leaderboard> {

--- a/src/services/lobby.ts
+++ b/src/services/lobby.ts
@@ -28,10 +28,9 @@ import {
 import { WavedashEvents } from "../events";
 import type { WavedashSDK } from "../index";
 import { api, IFRAME_MESSAGE_TYPE, SDKUser } from "@wvdsh/api";
+import { WavedashManager } from "./manager";
 
-export class LobbyManager {
-  private sdk: WavedashSDK;
-
+export class LobbyManager extends WavedashManager {
   // Track current lobby state
   private unsubscribeLobbyMessages: (() => void) | null = null;
   private unsubscribeLobbyUsers: (() => void) | null = null;
@@ -58,7 +57,7 @@ export class LobbyManager {
   private p2pUpdateQueue: Promise<void> = Promise.resolve();
 
   constructor(sdk: WavedashSDK) {
-    this.sdk = sdk;
+    super(sdk);
     this.unsubscribeLobbyInvites = this.sdk.convexClient.onUpdate(
       api.sdk.gameLobby.getLobbyInvites,
       {},

--- a/src/services/manager.ts
+++ b/src/services/manager.ts
@@ -1,0 +1,20 @@
+import type { WavedashSDK } from "../index";
+
+/**
+ * Base class for SDK managers. Provides the shared `sdk` reference and a
+ * default no-op `destroy()` so the SDK can safely iterate every manager
+ * during teardown without each one having to define an empty stub.
+ *
+ * Override `destroy()` in any manager that owns ongoing state — Convex
+ * subscriptions, intervals, peer connections, monkey-patched globals, etc.
+ * — to make sure that state is released when the SDK is torn down.
+ */
+export abstract class WavedashManager {
+  protected sdk: WavedashSDK;
+
+  constructor(sdk: WavedashSDK) {
+    this.sdk = sdk;
+  }
+
+  destroy(): void {}
+}

--- a/src/services/overlay.ts
+++ b/src/services/overlay.ts
@@ -1,5 +1,6 @@
 import { IFRAME_MESSAGE_TYPE } from "@wvdsh/api";
 import { type WavedashSDK } from "../index";
+import { WavedashManager } from "./manager";
 
 /**
  * OverlayManager
@@ -12,11 +13,9 @@ import { type WavedashSDK } from "../index";
  * - `takeFocus()` is also called after load completes so the game starts
  *   with keyboard focus without the player clicking first.
  */
-export class OverlayManager {
-  private sdk: WavedashSDK;
-
+export class OverlayManager extends WavedashManager {
   constructor(sdk: WavedashSDK) {
-    this.sdk = sdk;
+    super(sdk);
 
     this.sdk.iframeMessenger.addEventListener(
       IFRAME_MESSAGE_TYPE.TAKE_FOCUS,

--- a/src/services/p2p.ts
+++ b/src/services/p2p.ts
@@ -21,6 +21,7 @@ import type {
 } from "../types";
 import { WavedashEvents } from "../events";
 import type { WavedashSDK } from "../index";
+import { WavedashManager } from "./manager";
 import { api, P2P_SIGNALING_MESSAGE_TYPE, SDKUser } from "@wvdsh/api";
 
 // Internal P2P signaling/TURN types — not part of the public SDK surface.
@@ -43,8 +44,7 @@ const DEFAULT_P2P_CONFIG: Required<P2PConfig> = {
   maxIncomingMessages: 1024
 };
 
-export class P2PManager {
-  private sdk: WavedashSDK;
+export class P2PManager extends WavedashManager {
   private config: Required<P2PConfig>;
   private currentConnection: P2PConnection | null = null;
 
@@ -173,8 +173,12 @@ export class P2PManager {
   private initialized = false;
 
   constructor(sdk: WavedashSDK) {
-    this.sdk = sdk;
+    super(sdk);
     this.config = { ...DEFAULT_P2P_CONFIG };
+  }
+
+  destroy(): void {
+    this.disconnectP2P();
   }
 
   private ensureInitialized(): void {

--- a/src/services/stats.ts
+++ b/src/services/stats.ts
@@ -8,6 +8,12 @@ type StatEntry = { identifier: string; value: number };
 
 const STORE_DEBOUNCE_MS = 1000;
 
+// Background safety-net flush: persists any dirty stats/achievements that the
+// game forgot to flag with `storeNow`. Bounds worst-case data loss to this
+// interval if the session ends abruptly (the SDK can't reliably fire one last
+// mutation during iframe teardown — see comment in destroy()).
+const PERIODIC_PERSIST_MS = 10_000;
+
 export class StatsManager {
   private sdk: WavedashSDK;
 
@@ -30,16 +36,31 @@ export class StatsManager {
   // Subscription cleanup
   private subscriptions: (() => void)[] = [];
 
+  // Background flush timer — see PERIODIC_PERSIST_MS
+  private periodicPersistInterval: ReturnType<typeof setInterval> | null = null;
+
   constructor(sdk: WavedashSDK) {
     this.sdk = sdk;
     this.subscribe();
     this.requestStats().catch((error) => {
       this.sdk.logger.error("Initial stats fetch failed:", error);
     });
+    this.periodicPersistInterval = setInterval(() => {
+      void this.persist();
+    }, PERIODIC_PERSIST_MS);
   }
 
   destroy(): void {
+    // We deliberately do NOT fire a final persist here. By the time destroy()
+    // runs (in response to the parent's END_SESSION) the iframe is about to
+    // be detached, and Convex mutations go over the WebSocket — which has no
+    // `keepalive` equivalent. The mutation would die mid-flight. The
+    // PERIODIC_PERSIST_MS flush bounds worst-case loss to that window.
     this.debouncedPersist.cancel();
+    if (this.periodicPersistInterval !== null) {
+      clearInterval(this.periodicPersistInterval);
+      this.periodicPersistInterval = null;
+    }
     for (const unsub of this.subscriptions) unsub();
     this.subscriptions = [];
   }

--- a/src/services/stats.ts
+++ b/src/services/stats.ts
@@ -3,6 +3,7 @@ import type { WavedashSDK } from "..";
 import type { StatsStoredPayload } from "../types";
 import { WavedashEvents } from "../events";
 import debounce from "lodash.debounce";
+import { WavedashManager } from "./manager";
 
 type StatEntry = { identifier: string; value: number };
 
@@ -14,9 +15,7 @@ const STORE_DEBOUNCE_MS = 1000;
 // mutation during iframe teardown — see comment in destroy()).
 const PERIODIC_PERSIST_MS = 10_000;
 
-export class StatsManager {
-  private sdk: WavedashSDK;
-
+export class StatsManager extends WavedashManager {
   // Current user values
   private stats: Map<string, number> = new Map();
   private unlockedAchievements: Set<string> = new Set();
@@ -40,7 +39,7 @@ export class StatsManager {
   private periodicPersistInterval: ReturnType<typeof setInterval> | null = null;
 
   constructor(sdk: WavedashSDK) {
-    this.sdk = sdk;
+    super(sdk);
     this.subscribe();
     this.requestStats().catch((error) => {
       this.sdk.logger.error("Initial stats fetch failed:", error);
@@ -51,11 +50,6 @@ export class StatsManager {
   }
 
   destroy(): void {
-    // We deliberately do NOT fire a final persist here. By the time destroy()
-    // runs (in response to the parent's END_SESSION) the iframe is about to
-    // be detached, and Convex mutations go over the WebSocket — which has no
-    // `keepalive` equivalent. The mutation would die mid-flight. The
-    // PERIODIC_PERSIST_MS flush bounds worst-case loss to that window.
     this.debouncedPersist.cancel();
     if (this.periodicPersistInterval !== null) {
       clearInterval(this.periodicPersistInterval);

--- a/src/services/ugc.ts
+++ b/src/services/ugc.ts
@@ -7,12 +7,11 @@
 import type { Id, UGCType, UGCVisibility } from "../types";
 import type { WavedashSDK } from "../index";
 import { api } from "@wvdsh/api";
+import { WavedashManager } from "./manager";
 
-export class UGCManager {
-  private sdk: WavedashSDK;
-
+export class UGCManager extends WavedashManager {
   constructor(sdk: WavedashSDK) {
-    this.sdk = sdk;
+    super(sdk);
   }
 
   async createUGCItem(


### PR DESCRIPTION
Iframe gets removed from the DOM too quickly to fire off end of session network requests, let the parent handle the end-session POST

1. Keep the parent updated on the latest gameplayJWT and let it handle ending the session
2. Stats now have a 10s persist safety net in case the dev forgot to call storeNow, we have more control over persisting state that way than a last ditch POST as the page is unloading