### PR TITLE
userAvatarUrl in leaderboard entry return type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@wvdsh/sdk-js",
       "version": "1.3.6",
       "dependencies": {
-        "@wvdsh/api": "^0.1.14",
+        "@wvdsh/api": "^0.1.16",
         "convex": "^1.34.0",
         "lodash.throttle": "^4.1.1"
       },
@@ -1313,9 +1313,9 @@
       }
     },
     "node_modules/@wvdsh/api": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/@wvdsh/api/-/api-0.1.14.tgz",
-      "integrity": "sha512-PIyrsSUKsuOA+nWL5sCSsjRAphV8R1k9D2xXXcfqbIZ6EzjnnXRf1pGzm+j5Qlox0qekDyB98RMQIJ2OWOb6/A==",
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/@wvdsh/api/-/api-0.1.16.tgz",
+      "integrity": "sha512-WN6f8IQoNwqxVN4TC/N7cob11f4z7GESKZcdrEaAYJVeQvvbw3jeUCEFUxMWkf76GJvXKULG+FN4T6a8qXyI+A==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "typescript-eslint": "^8.52.0"
   },
   "dependencies": {
-    "@wvdsh/api": "^0.1.14",
+    "@wvdsh/api": "^0.1.16",
     "convex": "^1.34.0",
     "lodash.throttle": "^4.1.1"
   }

--- a/src/services/leaderboards.ts
+++ b/src/services/leaderboards.ts
@@ -122,7 +122,8 @@ export class LeaderboardManager extends WavedashManager {
     return {
       ...result.entry,
       userId: this.sdk.wavedashUser.id,
-      username: this.sdk.wavedashUser.username
+      username: this.sdk.wavedashUser.username,
+      userAvatarUrl: this.sdk.wavedashUser.avatarUrl
     };
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,7 @@ export type UpsertedLeaderboardEntry = FunctionReturnType<
 >["entry"] & {
   userId: Id<"users">;
   username: string;
+  userAvatarUrl?: string;
 };
 
 // Type helper to get event values as a union type


### PR DESCRIPTION
Entries now returned with each user's id, username, avatarUrl

Not adding leaderboard entries to the friend cache since you can page through hundreds of entries quickly, `getUserAvatarUrl` will continue to only be for friends and players you've shared a lobby with