### PR TITLE
Cache some leaderboard entry users

### DIFF
--- a/src/services/friends.ts
+++ b/src/services/friends.ts
@@ -17,16 +17,76 @@ interface CachedUser {
 }
 
 export class FriendsManager extends WavedashManager {
+  // Persistent cache for users with a durable relationship (self, friends, shared lobby).
   private userCache: Map<Id<"users">, CachedUser> = new Map();
+  // Transient cache for only the most recently loaded leaderboard page. Cleared on each new page.
+  private leaderboardPageUserCache: Map<Id<"users">, CachedUser> = new Map();
 
   constructor(sdk: WavedashSDK) {
     super(sdk);
   }
 
   /**
+   * Returns CDN URL with size transformation for a cached user's avatar.
+   * @param userId - The user ID to get the avatar URL for
+   * @param size - Pixel size for width and height. Use a value from
+   *   `AvatarSize` (SMALL=64, MEDIUM=128, LARGE=256) or any custom pixel size.
+   * @returns CDN URL with size transformation, or null if user not cached or has no avatar
+   */
+  getUserAvatarUrl(
+    userId: Id<"users">,
+    size: number = AvatarSize.MEDIUM
+  ): string | null {
+    const user =
+      this.userCache.get(userId) ?? this.leaderboardPageUserCache.get(userId);
+    if (!user?.avatarR2Key) {
+      return null;
+    }
+    return getCdnImageUrl(user.avatarR2Key, this.sdk.uploadsHost, {
+      width: size,
+      height: size,
+      fit: "cover",
+      quality: "high",
+      sharpen: 1
+    });
+  }
+
+  /**
+   * Returns the cached username for a given user ID
+   * @param userId - The user ID to get the username for
+   * @returns The username, or null if user not cached
+   */
+  getUsername(userId: Id<"users">): string | null {
+    return (
+      this.userCache.get(userId)?.username ??
+      this.leaderboardPageUserCache.get(userId)?.username ??
+      null
+    );
+  }
+
+  /**
+   * List all friends for the logged in user
+   * @returns Array<{
+   *   avatarUrl?: string;
+   *   isOnline: boolean;
+   *   userId: Id<"users">;
+   *   username: string;
+   * }>
+   */
+  async listFriends(): Promise<Friend[]> {
+    const friends = await this.sdk.convexClient.query(
+      api.sdk.friends.listFriends,
+      {}
+    );
+    this.cacheUsers(friends);
+    return friends;
+  }
+
+  /**
    * Cache users from any source (friends, lobby users)
    * Accepts both Friend format (avatarUrl) and LobbyUser format (userAvatarUrl)
    * @param users - Array of users with userId, username, and optional avatar r2Key
+   * @internal
    */
   cacheUsers(
     users: Array<{
@@ -46,44 +106,27 @@ export class FriendsManager extends WavedashManager {
   }
 
   /**
-   * Returns CDN URL with size transformation for a cached user's avatar.
-   * @param userId - The user ID to get the avatar URL for
-   * @param size - Pixel size for width and height. Use a value from
-   *   `AvatarSize` (SMALL=64, MEDIUM=128, LARGE=256) or any custom pixel size.
-   * @returns CDN URL with size transformation, or null if user not cached or has no avatar
+   * Replace the leaderboard-page cache with the users from a single page of
+   * leaderboard entries.
+   * 
+   * In general devs should just use the username and userAvatarUrl returned
+   * from `listLeaderboardEntries` directly, but we cache the latest leaderboard
+   * page here just so getUserAvatarUrl and getUsername still work for the current page.
+   * @internal
    */
-  getUserAvatarUrl(
-    userId: Id<"users">,
-    size: number = AvatarSize.MEDIUM
-  ): string | null {
-    const user = this.userCache.get(userId);
-    if (!user?.avatarR2Key) {
-      return null;
+  cacheLeaderboardPage(
+    users: Array<{
+      userId: Id<"users">;
+      username: string;
+      userAvatarUrl?: string;
+    }>
+  ): void {
+    this.leaderboardPageUserCache.clear();
+    for (const user of users) {
+      this.leaderboardPageUserCache.set(user.userId, {
+        username: user.username,
+        avatarR2Key: user.userAvatarUrl
+      });
     }
-    return getCdnImageUrl(user.avatarR2Key, this.sdk.uploadsHost, {
-      width: size,
-      height: size,
-      fit: "cover",
-      quality: "high",
-      sharpen: 1
-    });
-  }
-
-  /**
-   * Returns the cached username for a given user ID
-   * @param userId - The user ID to get the username for
-   * @returns The username, or null if user not cached
-   */
-  getUsername(userId: Id<"users">): string | null {
-    return this.userCache.get(userId)?.username ?? null;
-  }
-
-  async listFriends(): Promise<Friend[]> {
-    const friends = await this.sdk.convexClient.query(
-      api.sdk.friends.listFriends,
-      {}
-    );
-    this.cacheUsers(friends);
-    return friends;
   }
 }

--- a/src/services/leaderboards.ts
+++ b/src/services/leaderboards.ts
@@ -87,6 +87,7 @@ export class LeaderboardManager extends WavedashManager {
     if (result && result.totalEntries) {
       this.updateCachedTotalEntries(leaderboardId, result.totalEntries);
     }
+    this.sdk.friendsManager.cacheLeaderboardPage(result.entries);
     return result.entries;
   }
 
@@ -103,6 +104,7 @@ export class LeaderboardManager extends WavedashManager {
     if (result && result.totalEntries) {
       this.updateCachedTotalEntries(leaderboardId, result.totalEntries);
     }
+    this.sdk.friendsManager.cacheLeaderboardPage(result.entries);
     return result.entries;
   }
 

--- a/src/services/leaderboards.ts
+++ b/src/services/leaderboards.ts
@@ -65,7 +65,8 @@ export class LeaderboardManager extends WavedashManager {
       ? {
           ...result.entry,
           userId: this.sdk.wavedashUser.id,
-          username: this.sdk.wavedashUser.username
+          username: this.sdk.wavedashUser.username,
+          userAvatarUrl: this.sdk.wavedashUser.avatarUrl
         }
       : null;
 


### PR DESCRIPTION
Just cache the current page of leaderboard entry users in case devs want to use getUserAvatarUrl and getUsername for those entries, rather than the `username` and `userAvatarUrl` returned directly from `listLeaderboardEntries`