### PR TITLE
UGC API Updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@wvdsh/sdk-js",
       "version": "1.3.11",
       "dependencies": {
-        "@wvdsh/api": "^0.1.26",
+        "@wvdsh/api": "^0.1.27",
         "convex": "^1.38.0",
         "lodash.throttle": "^4.1.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@wvdsh/sdk-js",
       "version": "1.3.11",
       "dependencies": {
-        "@wvdsh/api": "^0.1.16",
+        "@wvdsh/api": "^0.1.25",
         "convex": "^1.38.0",
         "lodash.throttle": "^4.1.1"
       },
@@ -1313,9 +1313,9 @@
       }
     },
     "node_modules/@wvdsh/api": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/@wvdsh/api/-/api-0.1.16.tgz",
-      "integrity": "sha512-WN6f8IQoNwqxVN4TC/N7cob11f4z7GESKZcdrEaAYJVeQvvbw3jeUCEFUxMWkf76GJvXKULG+FN4T6a8qXyI+A==",
+      "version": "0.1.25",
+      "resolved": "https://registry.npmjs.org/@wvdsh/api/-/api-0.1.25.tgz",
+      "integrity": "sha512-8cem5DVNLrz/Jee+nT2euM/wxIa3KVD4hSUJRt+6GPxnlXrj81LpoA4oZWMV/fBWG1o8RyZuzgIZ0+FFLROaRQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@wvdsh/sdk-js",
       "version": "1.3.11",
       "dependencies": {
-        "@wvdsh/api": "^0.1.25",
+        "@wvdsh/api": "^0.1.26",
         "convex": "^1.38.0",
         "lodash.throttle": "^4.1.1"
       },
@@ -1313,9 +1313,9 @@
       }
     },
     "node_modules/@wvdsh/api": {
-      "version": "0.1.25",
-      "resolved": "https://registry.npmjs.org/@wvdsh/api/-/api-0.1.25.tgz",
-      "integrity": "sha512-8cem5DVNLrz/Jee+nT2euM/wxIa3KVD4hSUJRt+6GPxnlXrj81LpoA4oZWMV/fBWG1o8RyZuzgIZ0+FFLROaRQ==",
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/@wvdsh/api/-/api-0.1.27.tgz",
+      "integrity": "sha512-clQ+xL8VCOPA3XGKdv6XoSBEPPnArPcFrZ9M8zCGcp/y2hOdlmr5u7xfyXA2ncXMYWcteSHr0RzbPnFr5Oe9OA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "typescript-eslint": "^8.52.0"
   },
   "dependencies": {
-    "@wvdsh/api": "^0.1.16",
+    "@wvdsh/api": "^0.1.25",
     "convex": "^1.38.0",
     "lodash.throttle": "^4.1.1"
   }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "typescript-eslint": "^8.52.0"
   },
   "dependencies": {
-    "@wvdsh/api": "^0.1.25",
+    "@wvdsh/api": "^0.1.26",
     "convex": "^1.38.0",
     "lodash.throttle": "^4.1.1"
   }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "typescript-eslint": "^8.52.0"
   },
   "dependencies": {
-    "@wvdsh/api": "^0.1.26",
+    "@wvdsh/api": "^0.1.27",
     "convex": "^1.38.0",
     "lodash.throttle": "^4.1.1"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -670,13 +670,28 @@ class WavedashSDK extends EventTarget {
   /**
    * Updates a UGC item and uploads the file to the server if a filePath is provided
    * @param ugcId - The ID of the UGC item to update
-   * @param updates - Object containing the fields to update
+   * @param updates - Object containing the fields to update. May also be passed
+   *   as a JSON string by engine bridges (Godot) that can't marshal a dict.
    * @returns ugcId
    */
   async updateUGCItem(
     ugcId: Id<"userGeneratedContent">,
     updates: UpdateUGCItemArgs = {}
   ): Promise<WavedashResponse<Id<"userGeneratedContent">>> {
+    if (typeof updates === "string") {
+      const raw = updates;
+      try {
+        updates = JSON.parse(raw);
+      } catch (error) {
+        const message = `updateUGCItem: invalid JSON: ${raw}`;
+        logger.error(message, error);
+        return this.formatResponse({
+          success: false,
+          data: null,
+          message
+        });
+      }
+    }
     return this.apiCall(
       this.ugcManager,
       "updateUGCItem",
@@ -733,21 +748,47 @@ class WavedashSDK extends EventTarget {
   async listUGCItems(
     args: ListUGCItemsArgs = {}
   ): Promise<WavedashResponse<PaginatedUGCItems>> {
+    if (typeof args === "string") {
+      const raw = args;
+      try {
+        args = JSON.parse(raw);
+      } catch (error) {
+        const message = `listUGCItems: invalid JSON: ${raw}`;
+        logger.error(message, error);
+        return this.formatResponse({
+          success: false,
+          data: null,
+          message
+        });
+      }
+    }
     return this.apiCall(
       this.ugcManager,
       "listUGCItems",
       [
         [
           "args",
-          vOptional(
-            vObject({
+          vOptional((value, path) => {
+            const obj = vObject({
               createdBy: vOptional(vId("users")),
               ugcType: vOptional(vEnum(UGC_TYPE, "UGCType")),
               titleSearch: vOptional(vString),
               numItems: vOptional(vNumber),
               continueCursor: vOptional(vString)
-            })
-          )
+            })(value, path);
+            if (
+              obj.continueCursor !== undefined &&
+              (obj.createdBy !== undefined ||
+                obj.ugcType !== undefined ||
+                obj.titleSearch !== undefined ||
+                obj.numItems !== undefined)
+            ) {
+              throw new Error(
+                `${path}: continueCursor should be the only argument if present`
+              );
+            }
+            return obj;
+          })
         ]
       ],
       args

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,8 @@ import type {
   UGCType,
   UGCVisibility,
   UpdateUGCItemArgs,
+  PaginatedUGCItems,
+  ListUGCItemsArgs,
   RemoteFileMetadata,
   P2PMessage,
   LobbyUser,
@@ -728,6 +730,30 @@ class WavedashSDK extends EventTarget {
     );
   }
 
+  async listUGCItems(
+    args: ListUGCItemsArgs = {}
+  ): Promise<WavedashResponse<PaginatedUGCItems>> {
+    return this.apiCall(
+      this.ugcManager,
+      "listUGCItems",
+      [
+        [
+          "args",
+          vOptional(
+            vObject({
+              createdBy: vOptional(vId("users")),
+              ugcType: vOptional(vEnum(UGC_TYPE, "UGCType")),
+              titleSearch: vOptional(vString),
+              numItems: vOptional(vNumber),
+              continueCursor: vOptional(vString)
+            })
+          )
+        ]
+      ],
+      args
+    );
+  }
+
   // ================================
   // Save state / Remote File Storage
   // ================================
@@ -1216,12 +1242,11 @@ class WavedashSDK extends EventTarget {
   // ==============================
   /**
    * Updates rich user presence so friends can see what the player is doing in game
-   * TODO: data param should be more strongly typed
    * @param data Game data to send to the backend
    * @returns true if the presence was updated successfully
    */
   async updateUserPresence(
-    data?: Record<string, unknown>
+    data?: Record<string, string | number | boolean | null>
   ): Promise<WavedashResponse<boolean>> {
     return this.apiCall(
       this.heartbeatManager,

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ import type {
   UpsertedLeaderboardEntry,
   UGCType,
   UGCVisibility,
+  UpdateUGCItemArgs,
   RemoteFileMetadata,
   P2PMessage,
   LobbyUser,
@@ -66,7 +67,8 @@ import {
   vRecord,
   vString,
   vUint8Array,
-  vUnion
+  vUnion,
+  vObject
 } from "./utils/validation";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -665,36 +667,33 @@ class WavedashSDK extends EventTarget {
 
   /**
    * Updates a UGC item and uploads the file to the server if a filePath is provided
-   * TODO: GD Script cannot call with optional arguments, convert this to accept a single dictionary of updates
-   * @param ugcId
-   * @param title
-   * @param description
-   * @param visibility
-   * @param filePath - optional IndexedDB key file path to upload to the server. If not provided, the UGC item will be updated but no file will be uploaded.
+   * @param ugcId - The ID of the UGC item to update
+   * @param updates - Object containing the fields to update
    * @returns ugcId
    */
   async updateUGCItem(
     ugcId: Id<"userGeneratedContent">,
-    title?: string,
-    description?: string,
-    visibility?: UGCVisibility,
-    filePath?: string
+    updates: UpdateUGCItemArgs = {}
   ): Promise<WavedashResponse<Id<"userGeneratedContent">>> {
     return this.apiCall(
       this.ugcManager,
       "updateUGCItem",
       [
         ["ugcId", vId("userGeneratedContent")],
-        ["title", vOptional(vString)],
-        ["description", vOptional(vString)],
-        ["visibility", vOptional(vEnum(UGC_VISIBILITY, "UGCVisibility"))],
-        ["filePath", vOptional(vString)]
+        [
+          "updates",
+          vOptional(
+            vObject({
+              title: vOptional(vString),
+              description: vOptional(vString),
+              visibility: vOptional(vEnum(UGC_VISIBILITY, "UGCVisibility")),
+              filePath: vOptional(vString)
+            })
+          )
+        ]
       ],
       ugcId,
-      title,
-      description,
-      visibility,
-      filePath
+      updates
     );
   }
 

--- a/src/services/heartbeat.ts
+++ b/src/services/heartbeat.ts
@@ -161,7 +161,9 @@ export class HeartbeatManager extends WavedashManager {
    * @param data - Data to send to the backend
    * @returns true if the presence was updated successfully
    */
-  async updateUserPresence(data?: Record<string, unknown>): Promise<boolean> {
+  async updateUserPresence(
+    data?: Record<string, string | number | boolean | null>
+  ): Promise<boolean> {
     try {
       // Add a default value to guarantee that the presence is updated
       const dataToSend = data ?? { forceUpdate: true };

--- a/src/services/p2p.ts
+++ b/src/services/p2p.ts
@@ -1271,7 +1271,8 @@ export class P2PManager extends WavedashManager {
           lobbyId: this.currentConnection.lobbyId,
           toUserId: toUserId,
           messageType: message.type,
-          data: message.data
+          data: message.data as Record<string, string | number | null>
+
         }
       );
       logger.debug("Sent signaling message:", message.type);

--- a/src/services/ugc.ts
+++ b/src/services/ugc.ts
@@ -4,7 +4,7 @@
  * Implements each of the user generated content methods of the Wavedash SDK
  */
 
-import type { Id, UGCType, UGCVisibility } from "../types";
+import type { Id, UGCType, UGCVisibility, UpdateUGCItemArgs } from "../types";
 import type { WavedashSDK } from "../index";
 import { api } from "@wvdsh/api";
 import { WavedashManager } from "./manager";
@@ -49,11 +49,9 @@ export class UGCManager extends WavedashManager {
 
   async updateUGCItem(
     ugcId: Id<"userGeneratedContent">,
-    title?: string,
-    description?: string,
-    visibility?: UGCVisibility,
-    filePath?: string
+    updates: UpdateUGCItemArgs = {}
   ): Promise<Id<"userGeneratedContent">> {
+    const { title, description, visibility, filePath } = updates;
     const { uploadUrl } = await this.sdk.convexClient.mutation(
       api.sdk.userGeneratedContent.updateUGCItem,
       {

--- a/src/services/ugc.ts
+++ b/src/services/ugc.ts
@@ -4,7 +4,14 @@
  * Implements each of the user generated content methods of the Wavedash SDK
  */
 
-import type { Id, UGCType, UGCVisibility, UpdateUGCItemArgs } from "../types";
+import type {
+  Id,
+  UGCType,
+  UGCVisibility,
+  UpdateUGCItemArgs,
+  PaginatedUGCItems,
+  ListUGCItemsArgs
+} from "../types";
 import type { WavedashSDK } from "../index";
 import { api } from "@wvdsh/api";
 import { WavedashManager } from "./manager";
@@ -103,5 +110,23 @@ export class UGCManager extends WavedashManager {
       throw new Error(`Failed to download UGC item ${ugcId}: ${msg}`);
     }
     return ugcId;
+  }
+
+  async listUGCItems(args: ListUGCItemsArgs = {}): Promise<PaginatedUGCItems> {
+    const { createdBy, ugcType, titleSearch, numItems, continueCursor } = args;
+    const filters =
+      createdBy !== undefined ||
+      ugcType !== undefined ||
+      titleSearch !== undefined
+        ? { createdBy, ugcType, titleSearch }
+        : undefined;
+    return await this.sdk.convexClient.query(
+      api.sdk.userGeneratedContent.listUGCItems,
+      {
+        filters,
+        numItems,
+        continueCursor
+      }
+    );
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@
  */
 
 import { type GenericId as Id } from "convex/values";
-import { type FunctionReturnType } from "convex/server";
+import { type FunctionReturnType, type FunctionArgs } from "convex/server";
 
 import { WavedashEvents } from "./events";
 import { api } from "@wvdsh/api";
@@ -29,6 +29,13 @@ export type LeaderboardDisplayType =
 export type UGCType = (typeof UGC_TYPE)[keyof typeof UGC_TYPE];
 export type UGCVisibility =
   (typeof UGC_VISIBILITY)[keyof typeof UGC_VISIBILITY];
+
+export type UpdateUGCItemArgs = Omit<
+  FunctionArgs<typeof api.sdk.userGeneratedContent.updateUGCItem>,
+  "ugcId" | "createPresignedUploadUrl"
+> & {
+  filePath?: string;
+};
 
 // Function return type aliases derived from the API
 export type LobbyUser = FunctionReturnType<

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,19 @@ export type UpdateUGCItemArgs = Omit<
   filePath?: string;
 };
 
+export type UGCItem = FunctionReturnType<
+  typeof api.sdk.userGeneratedContent.listUGCItems
+>["page"][0];
+export type PaginatedUGCItems = FunctionReturnType<
+  typeof api.sdk.userGeneratedContent.listUGCItems
+>;
+type RawListUGCItemsArgs = FunctionArgs<
+  typeof api.sdk.userGeneratedContent.listUGCItems
+>;
+
+export type ListUGCItemsArgs = Omit<RawListUGCItemsArgs, "filters"> &
+  NonNullable<RawListUGCItemsArgs["filters"]>;
+
 // Function return type aliases derived from the API
 export type LobbyUser = FunctionReturnType<
   typeof api.sdk.gameLobby.lobbyUsers

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -128,22 +128,55 @@ export function vUnion<T>(...variants: Validator<T>[]): Validator<T> {
   };
 }
 
+/**
+ * Validate an object's shape and key names.
+ * Ensures all keys in the value are present in the shape (detecting typos)
+ * and runs each field's validator.
+ */
+export function vObject<T extends Record<string, unknown>>(shape: {
+  [K in keyof T]: Validator<T[K]>;
+}): Validator<T> {
+  return (value, path) => {
+    const obj = vRecord(value, path);
+
+    // Check for extraneous keys (typos / unrecognized fields)
+    for (const key of Object.keys(obj)) {
+      if (!(key in shape)) {
+        throw new Error(`${path}: unrecognized property "${key}"`);
+      }
+    }
+
+    // Validate each expected key in the shape
+    for (const key of Object.keys(shape) as (keyof T)[]) {
+      shape[key](obj[key as string], `${path}.${key as string}`);
+    }
+
+    return obj as T;
+  };
+}
+
 /** Pair of `[argName, validator]` used by `validateArgs`. */
 export type ArgSpec = readonly [name: string, validator: Validator<unknown>];
 
 /**
  * Validate a list of positional arguments against their specs.
- * Throws on the first failure with a clear message including method + arg name.
+ * Uses vObject internally to unify all argument validation.
  */
 export function validateArgs(
   methodName: string,
   specs: readonly ArgSpec[],
   values: readonly unknown[]
 ): void {
+  const shape: Record<string, Validator<unknown>> = {};
+  const obj: Record<string, unknown> = {};
+
   for (let i = 0; i < specs.length; i++) {
     const [argName, validator] = specs[i];
-    validator(values[i], `${methodName}.${argName}`);
+    shape[argName] = validator;
+    obj[argName] = values[i];
   }
+
+  vObject(shape)(obj, methodName);
 }
 
 function describeValue(value: unknown): string {


### PR DESCRIPTION
updateUGCItem accepts a dict so engine callers do not need to pass every positional arg
listUGCItem with createdBy / titleSearch / ugcType filters + continueCursor for pagination

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the public `updateUGCItem` signature and adds new validation rules that can reject previously accepted inputs, potentially impacting existing engine integrations.
> 
> **Overview**
> **UGC API updates:** `updateUGCItem` now takes a single `updates` object (or JSON string for engine bridges) instead of multiple positional optional params, with strict key/shape validation to catch typos.
> 
> Adds `listUGCItems` with optional filters (`createdBy`, `ugcType`, `titleSearch`) and cursor-based pagination; the SDK enforces that `continueCursor` can’t be combined with other args.
> 
> Also tightens presence/signaling payload typings and bumps `@wvdsh/api` to `^0.1.27` (lockfile updated), plus introduces `vObject` and routes `validateArgs` through it to reject unrecognized argument names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74379ad2ca872025af65ee955f1b86d82fb20c77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->