### PR TITLE
Update user presence

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1282,17 +1282,37 @@ class WavedashSDK extends EventTarget {
   // User Presence
   // ==============================
   /**
-   * Updates rich user presence so friends can see what the player is doing in game
-   * @param data Game data to send to the backend
+   * Updates rich user presence so friends can see what the player is doing in game.
+   * Supported keys:
+   *   `status`  — one-line activity shown as the primary line (e.g. "Traveling in a group")
+   *   `details` — secondary context shown beneath the status (e.g. current zone or mode)
+   * Pass `null` for an individual key to clear that field. Pass an empty object to send
+   * a heartbeat without changing fields.
+   * @param data Presence fields. May also be passed as a JSON string by engine
+   *   bridges (Godot, Unity) that can't marshal a plain dict.
    * @returns true if the presence was updated successfully
    */
   async updateUserPresence(
-    data?: Record<string, string | number | boolean | null>
+    data: Record<string, string | number | boolean | null>
   ): Promise<WavedashResponse<boolean>> {
+    if (typeof data === "string") {
+      const raw = data as string;
+      try {
+        data = JSON.parse(raw);
+      } catch (error) {
+        const message = `updateUserPresence: invalid JSON: ${raw}`;
+        logger.error(message, error);
+        return this.formatResponse({
+          success: false,
+          data: null,
+          message
+        });
+      }
+    }
     return this.apiCall(
       this.heartbeatManager,
       "updateUserPresence",
-      [["data", vOptional(vRecord)]],
+      [["data", vRecord]],
       data
     );
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1286,10 +1286,9 @@ class WavedashSDK extends EventTarget {
    * Supported keys:
    *   `status`  — one-line activity shown as the primary line (e.g. "Traveling in a group")
    *   `details` — secondary context shown beneath the status (e.g. current zone or mode)
-   * Pass `null` for an individual key to clear that field. Pass an empty object to send
-   * a heartbeat without changing fields.
-   * @param data Presence fields. May also be passed as a JSON string by engine
-   *   bridges (Godot, Unity) that can't marshal a plain dict.
+   * 
+   * Pass an empty dictionary to clear all presence fields.
+   * @param data Presence fields to update.
    * @returns true if the presence was updated successfully
    */
   async updateUserPresence(

--- a/src/services/heartbeat.ts
+++ b/src/services/heartbeat.ts
@@ -34,6 +34,7 @@ export class HeartbeatManager extends WavedashManager {
   private isFirstTick: boolean = true;
   private readonly TEST_CONNECTION_INTERVAL_MS = 1_000;
   private readonly DISCONNECTED_TIMEOUT_MS = 90_000;
+  private cachedPresenceData: Record<string, string | number | boolean | null> = {};
 
   constructor(sdk: WavedashSDK) {
     super(sdk);
@@ -138,7 +139,7 @@ export class HeartbeatManager extends WavedashManager {
       .mutation(api.sdk.presence.heartbeat, {
         ...(reestablish
           ? {
-              data: { forceUpdate: true },
+              data: this.cachedPresenceData,
               deviceFingerprint: this.deviceFingerprint
             }
           : {})
@@ -158,8 +159,6 @@ export class HeartbeatManager extends WavedashManager {
 
   /**
    * Updates user presence in the backend.
-   * Empty object sends a heartbeat without changing fields; `null` values clear
-   * individual keys.
    * @param data - Data to send to the backend
    * @returns true if the presence was updated successfully
    */
@@ -167,6 +166,7 @@ export class HeartbeatManager extends WavedashManager {
     data: Record<string, string | number | boolean | null>
   ): Promise<boolean> {
     try {
+      this.cachedPresenceData = data;
       await this.sdk.convexClient.mutation(api.sdk.presence.heartbeat, {
         data,
         deviceFingerprint: this.deviceFingerprint

--- a/src/services/heartbeat.ts
+++ b/src/services/heartbeat.ts
@@ -157,18 +157,18 @@ export class HeartbeatManager extends WavedashManager {
   }
 
   /**
-   * Updates user presence in the backend
+   * Updates user presence in the backend.
+   * Empty object sends a heartbeat without changing fields; `null` values clear
+   * individual keys.
    * @param data - Data to send to the backend
    * @returns true if the presence was updated successfully
    */
   async updateUserPresence(
-    data?: Record<string, string | number | boolean | null>
+    data: Record<string, string | number | boolean | null>
   ): Promise<boolean> {
     try {
-      // Add a default value to guarantee that the presence is updated
-      const dataToSend = data ?? { forceUpdate: true };
       await this.sdk.convexClient.mutation(api.sdk.presence.heartbeat, {
-        data: dataToSend,
+        data,
         deviceFingerprint: this.deviceFingerprint
       });
       return true;

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -58,13 +58,20 @@ export const vUint8Array: Validator<Uint8Array> = (value, path) => {
   return value;
 };
 
-export const vRecord: Validator<Record<string, unknown>> = (value, path) => {
+export const vRecord: Validator<Record<string, string | number | boolean | null>> = (value, path) => {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new Error(
       `${path}: expected plain object, got ${describeValue(value)}`
     );
   }
-  return value as Record<string, unknown>;
+  for (const [key, val] of Object.entries(value)) {
+    if (typeof val === "object" && val !== null) {
+      throw new Error(
+        `${path}: expected flat record with no nested objects, but key "${key}" contains ${describeValue(val)}`
+      );
+    }
+  }
+  return value as Record<string, string | number | boolean | null>;
 };
 
 /**
@@ -137,7 +144,12 @@ export function vObject<T extends Record<string, unknown>>(shape: {
   [K in keyof T]: Validator<T[K]>;
 }): Validator<T> {
   return (value, path) => {
-    const obj = vRecord(value, path);
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+      throw new Error(
+        `${path}: expected plain object, got ${describeValue(value)}`
+      );
+    }
+    const obj = value as Record<string, unknown>;
 
     // Check for extraneous keys (typos / unrecognized fields)
     for (const key of Object.keys(obj)) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Breaking API change (optional `data` removed) and altered heartbeat reconnect behavior affect all games using presence; validation is stricter on payload shape.
> 
> **Overview**
> **User presence** is now an explicit, validated payload instead of an optional blob with a hidden `forceUpdate` default.
> 
> `updateUserPresence` **requires** a flat record (`status`, `details`, etc.); omitting args is no longer supported—pass `{}` to clear. The public API documents those fields, accepts **JSON strings** from Godot (like other SDK methods), and validates with **`vRecord`** (no nested objects). **`HeartbeatManager`** caches the last presence and sends it on **re-establish** heartbeats instead of `{ forceUpdate: true }`, so reconnects keep friends’ view in sync without a separate update call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 935af8b9993c564ef870132adfe10c8563404cd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->