### PR TITLE
Handle mute/unmute from parent player

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@wvdsh/sdk-js",
       "version": "1.3.12",
       "dependencies": {
-        "@wvdsh/api": "^0.1.27",
-        "convex": "^1.38.0",
+        "@wvdsh/api": "^0.1.28",
+        "convex": "^1.39.1",
         "lodash.throttle": "^4.1.1"
       },
       "devDependencies": {
@@ -1313,15 +1313,15 @@
       }
     },
     "node_modules/@wvdsh/api": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/@wvdsh/api/-/api-0.1.27.tgz",
-      "integrity": "sha512-clQ+xL8VCOPA3XGKdv6XoSBEPPnArPcFrZ9M8zCGcp/y2hOdlmr5u7xfyXA2ncXMYWcteSHr0RzbPnFr5Oe9OA==",
+      "version": "0.1.28",
+      "resolved": "https://registry.npmjs.org/@wvdsh/api/-/api-0.1.28.tgz",
+      "integrity": "sha512-BYapb1x0I3Zc1ANuGCE9g6f2h3ttUmBBvVhoQ/1sv40YNck+JEf5XAqaxVH+bwTtiyBBF7X4vvRoXDeHFgXprg==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "convex": "^1.28.2"
+        "convex": "^1.39.1"
       }
     },
     "node_modules/acorn": {

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "typescript-eslint": "^8.52.0"
   },
   "dependencies": {
-    "@wvdsh/api": "^0.1.27",
-    "convex": "^1.38.0",
+    "@wvdsh/api": "^0.1.28",
+    "convex": "^1.39.1",
     "lodash.throttle": "^4.1.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { HeartbeatManager } from "./services/heartbeat";
 import { GameEventManager } from "./services/gameEvents";
 import { FullscreenManager } from "./services/fullscreen";
 import { OverlayManager } from "./services/overlay";
+import { AudioManager } from "./services/audio";
 import { FriendsManager } from "./services/friends";
 import { logger, LOG_LEVEL } from "./utils/logger";
 import { IFrameMessenger } from "./utils/iframeMessenger";
@@ -121,6 +122,7 @@ class WavedashSDK extends EventTarget {
   p2pManager: P2PManager;
   fullscreenManager: FullscreenManager;
   overlayManager: OverlayManager;
+  audioManager: AudioManager;
   private managers: WavedashManager[];
   private gameplayJwt: string | null = null;
   private gameplayJwtPromise: Promise<string> | null = null;
@@ -153,6 +155,7 @@ class WavedashSDK extends EventTarget {
     this.gameEventManager = new GameEventManager(this);
     this.fullscreenManager = new FullscreenManager(this);
     this.overlayManager = new OverlayManager(this);
+    this.audioManager = new AudioManager(this);
 
     // Single source of truth for teardown — `destroy()` iterates this list.
     // Order matches construction so destroys happen in dependency order
@@ -168,7 +171,8 @@ class WavedashSDK extends EventTarget {
       this.friendsManager,
       this.gameEventManager,
       this.fullscreenManager,
-      this.overlayManager
+      this.overlayManager,
+      this.audioManager
     ];
 
     // Cache current user for avatar lookups

--- a/src/services/audio.ts
+++ b/src/services/audio.ts
@@ -1,0 +1,274 @@
+import { IFRAME_MESSAGE_TYPE } from "@wvdsh/api";
+import { type WavedashSDK } from "../index";
+import { WavedashManager } from "./manager";
+import { logger } from "../utils/logger";
+
+/**
+ * Set of WeakRefs — lets us iterate tracked elements without preventing GC.
+ * Stale entries are purged lazily during iteration.
+ */
+class WeakRefSet<T extends object> {
+  private set = new Set<WeakRef<T>>();
+
+  add(value: T): void {
+    for (const ref of this.set) {
+      if (ref.deref() === value) return;
+    }
+    this.set.add(new WeakRef(value));
+  }
+
+  forEach(callback: (value: T) => void): void {
+    for (const ref of this.set) {
+      const v = ref.deref();
+      if (v === undefined) this.set.delete(ref);
+      else callback(v);
+    }
+  }
+
+  clear(): void {
+    this.set.clear();
+  }
+}
+
+/**
+ * AudioManager
+ *
+ * Mutes & unmutes the game in response to MUTE_CHANGED iframe messages, without
+ * the game needing to know anything about it.
+ *
+ * Web Audio: subclass `AudioContext` so `ctx.destination` resolves to a master
+ * GainNode that we control. The master gain wires to the real native destination,
+ * so `node.connect(ctx.destination)` and any other game code is unaffected.
+ *
+ * HTML Media (`<audio>`/`<video>`): override `HTMLMediaElement.prototype.muted`
+ * to record the game's intended state, but write `true` to the underlying element
+ * whenever the SDK is muted. Tracked elements come from three sources:
+ *  1. Pre-existing DOM media (`querySelectorAll`)
+ *  2. `new Audio()` constructor shim (covers detached SFX)
+ *  3. MutationObserver for any media added to the DOM later (covers innerHTML,
+ *     framework rendering, createElement + append, etc.)
+ */
+export class AudioManager extends WavedashManager {
+  private _isMuted = false;
+
+  // Web Audio contexts and their master gain nodes
+  private contexts = new Map<AudioContext, GainNode>();
+
+  // HTML media elements we know about + their game-intended muted state
+  private elements = new WeakRefSet<HTMLMediaElement>();
+  private intendedMuted = new WeakMap<HTMLMediaElement, boolean>();
+
+  // Originals (restored on destroy)
+  private originalAudioContext: typeof AudioContext | null = null;
+  private originalWebKitAudioContext: typeof AudioContext | null = null;
+  private originalAudio: typeof Audio | null = null;
+  private originalMutedDescriptor: PropertyDescriptor | null = null;
+  private mutationObserver: MutationObserver | null = null;
+
+  constructor(sdk: WavedashSDK) {
+    super(sdk);
+    this.installShims();
+    this.sdk.iframeMessenger.addEventListener(
+      IFRAME_MESSAGE_TYPE.MUTE_CHANGED,
+      this.handleMute
+    );
+  }
+
+  isMuted(): boolean {
+    return this._isMuted;
+  }
+
+  private handleMute = (data: { isMuted: boolean }): void => {
+    if (this._isMuted === data.isMuted) return;
+    this._isMuted = data.isMuted;
+    logger.debug(`[AudioManager] muted=${this._isMuted}`);
+
+    // Web Audio: short ramp avoids audible pops on instant 0↔1 jumps
+    const target = this._isMuted ? 0 : 1;
+    this.contexts.forEach((gain, ctx) => {
+      const now = ctx.currentTime;
+      gain.gain.setValueAtTime(gain.gain.value, now);
+      gain.gain.linearRampToValueAtTime(target, now + 0.05);
+    });
+
+    // HTML Media: force native muted=true while muted, restore intent on unmute
+    const setMutedNative = this.originalMutedDescriptor?.set;
+    if (setMutedNative) {
+      this.elements.forEach((el) => {
+        const intended = this.intendedMuted.get(el) ?? false;
+        setMutedNative.call(el, this._isMuted ? true : intended);
+      });
+    }
+  };
+
+  /**
+   * Track a media element and (if SDK is currently muted) silence it.
+   * Idempotent — safe to call multiple times for the same element.
+   */
+  private trackElement(el: HTMLMediaElement): void {
+    if (this.intendedMuted.has(el)) return;
+    const getMuted = this.originalMutedDescriptor?.get;
+    const setMuted = this.originalMutedDescriptor?.set;
+    const current = getMuted ? getMuted.call(el) : el.muted;
+    this.intendedMuted.set(el, current);
+    this.elements.add(el);
+    if (this._isMuted && !current && setMuted) {
+      setMuted.call(el, true);
+    }
+  }
+
+  private installShims(): void {
+    if (typeof window === "undefined") return;
+
+    // 1. AudioContext (+ webkit prefix): subclass to redirect destination
+    if (window.AudioContext) {
+      this.originalAudioContext = window.AudioContext;
+      window.AudioContext = this.shimAudioContextClass(window.AudioContext);
+    }
+    const win = window as unknown as Window & {
+      webkitAudioContext?: typeof AudioContext;
+    };
+    if (win.webkitAudioContext) {
+      this.originalWebKitAudioContext = win.webkitAudioContext;
+      win.webkitAudioContext = this.shimAudioContextClass(win.webkitAudioContext);
+    }
+
+    // 2. `new Audio()` — common pattern for detached one-shot SFX that never
+    //    enters the DOM (so the MutationObserver below wouldn't catch it).
+    if (window.Audio) {
+      const OriginalAudio = window.Audio;
+      this.originalAudio = OriginalAudio;
+      ((manager) => {
+        const Shimmed = function (src?: string) {
+          const audio = new OriginalAudio(src);
+          manager.trackElement(audio);
+          return audio;
+        };
+        Shimmed.prototype = OriginalAudio.prototype;
+        window.Audio = Shimmed as unknown as typeof Audio;
+      })(this);
+    }
+
+    if (typeof document !== "undefined") {
+      // 3a. Pre-existing DOM media at SDK init.
+      document.querySelectorAll("audio, video").forEach((el) => {
+        this.trackElement(el as HTMLMediaElement);
+      });
+
+      // 3b. MutationObserver picks up anything added to the DOM later —
+      //     covers innerHTML, framework rendering, createElement + append, etc.
+      this.mutationObserver = new MutationObserver((mutations) => {
+        for (const m of mutations) {
+          m.addedNodes.forEach((node) => {
+            if (node instanceof HTMLMediaElement) {
+              this.trackElement(node);
+            } else if (node instanceof HTMLElement) {
+              node.querySelectorAll("audio, video").forEach((el) => {
+                this.trackElement(el as HTMLMediaElement);
+              });
+            }
+          });
+        }
+      });
+      this.mutationObserver.observe(document.documentElement, {
+        childList: true,
+        subtree: true
+      });
+    }
+
+    // 4. Override HTMLMediaElement.prototype.muted so the game sees its own
+    //    intended value while we silently force the underlying element to true.
+    this.originalMutedDescriptor =
+      Object.getOwnPropertyDescriptor(HTMLMediaElement.prototype, "muted") ??
+      null;
+    const original = this.originalMutedDescriptor;
+    if (original?.get && original?.set) {
+      ((manager) => {
+        Object.defineProperty(HTMLMediaElement.prototype, "muted", {
+          configurable: true,
+          get(this: HTMLMediaElement): boolean {
+            const intended = manager.intendedMuted.get(this);
+            return intended !== undefined ? intended : original.get!.call(this);
+          },
+          set(this: HTMLMediaElement, value: boolean) {
+            manager.intendedMuted.set(this, value);
+            manager.elements.add(this);
+            original.set!.call(this, manager._isMuted ? true : value);
+          }
+        });
+      })(this);
+    }
+  }
+
+  private shimAudioContextClass(
+    Original: typeof AudioContext
+  ): typeof AudioContext {
+    return ((manager) =>
+      class extends Original {
+        constructor(opts?: AudioContextOptions) {
+          super(opts);
+          const masterGain = this.createGain();
+          masterGain.connect(this.destination);
+          masterGain.gain.setValueAtTime(
+            manager._isMuted ? 0 : 1,
+            this.currentTime
+          );
+          // Redirect ctx.destination → masterGain. Game code calling
+          // `node.connect(ctx.destination)` keeps working transparently.
+          Object.defineProperty(this, "destination", {
+            configurable: true,
+            get() {
+              return masterGain;
+            }
+          });
+          manager.contexts.set(this, masterGain);
+        }
+
+        close(): Promise<void> {
+          manager.contexts.delete(this);
+          return super.close();
+        }
+      })(this);
+  }
+
+  override destroy(): void {
+    this.sdk.iframeMessenger.removeEventListener(
+      IFRAME_MESSAGE_TYPE.MUTE_CHANGED,
+      this.handleMute
+    );
+
+    if (this.mutationObserver) {
+      this.mutationObserver.disconnect();
+      this.mutationObserver = null;
+    }
+
+    if (typeof window !== "undefined") {
+      if (this.originalAudioContext) {
+        window.AudioContext = this.originalAudioContext;
+      }
+      const win = window as unknown as Window & {
+        webkitAudioContext?: typeof AudioContext;
+      };
+      if (this.originalWebKitAudioContext && win.webkitAudioContext) {
+        win.webkitAudioContext = this.originalWebKitAudioContext;
+      }
+      if (this.originalAudio) {
+        window.Audio = this.originalAudio;
+      }
+    }
+
+    if (this.originalMutedDescriptor) {
+      Object.defineProperty(
+        HTMLMediaElement.prototype,
+        "muted",
+        this.originalMutedDescriptor
+      );
+    }
+
+    this.contexts.clear();
+    this.elements.clear();
+    this.intendedMuted = new WeakMap();
+
+    super.destroy();
+  }
+}

--- a/src/services/audio.ts
+++ b/src/services/audio.ts
@@ -83,10 +83,13 @@ export class AudioManager extends WavedashManager {
     this._isMuted = data.isMuted;
     logger.debug(`[AudioManager] muted=${this._isMuted}`);
 
-    // Web Audio: short ramp avoids audible pops on instant 0↔1 jumps
+    // Web Audio: short ramp avoids audible pops on instant 0↔1 jumps.
+    // cancelScheduledValues clears any in-flight ramp from a recent toggle so
+    // we don't follow a stale target before reaching the new one.
     const target = this._isMuted ? 0 : 1;
     this.contexts.forEach((gain, ctx) => {
       const now = ctx.currentTime;
+      gain.gain.cancelScheduledValues(now);
       gain.gain.setValueAtTime(gain.gain.value, now);
       gain.gain.linearRampToValueAtTime(target, now + 0.05);
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "ES2020",
-    "lib": ["ES2020", "DOM"],
+    "lib": ["ES2020", "ES2021.WeakRef", "DOM"],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
SDK shims AudioContext + `audio` `video` elements through a master gain
Handle `MUTE_CHANGED` iframe message event from parent player controls

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Global monkey-patches on AudioContext, Audio, and HTMLMediaElement.muted affect all audio in the iframe; teardown restores originals, but bugs could leak muted state or break game audio expectations.
> 
> **Overview**
> Adds **`AudioManager`** so the embedded game honors the parent player’s mute control via **`MUTE_CHANGED`** iframe messages, without game code changes.
> 
> **Web Audio:** replaces `AudioContext` (and `webkitAudioContext`) with a subclass that routes `destination` through a **master `GainNode`**, then ramps gain on mute/unmute to avoid pops.
> 
> **HTML media:** shims `Audio`, tracks `<audio>` / `<video>` (existing DOM, `MutationObserver`, and detached `new Audio()`), and overrides **`HTMLMediaElement.prototype.muted`** so the game still sees its intended mute state while the SDK forces silence when muted. Shims are **restored in `destroy()`** alongside other managers.
> 
> Also bumps **`@wvdsh/api`** to `^0.1.28` and **`convex`** to `^1.39.1`, and enables **`ES2021.WeakRef`** in `tsconfig` for element tracking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0061b8b29f64f89af6474efe71b0b56b4417b0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->