### PR TITLE
Notify game if audio mute state changes

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -33,7 +33,10 @@ export const WavedashEvents = {
   BACKEND_RECONNECTING: "BackendReconnecting", // attempting to reconnect to backend
 
   // Fullscreen events
-  FULLSCREEN_CHANGED: "FullscreenChanged" // fullscreen state changed
+  FULLSCREEN_CHANGED: "FullscreenChanged", // fullscreen state changed
+
+  // Audio events
+  MUTE_CHANGED: "MuteChanged" // mute state changed
 
   // TODO: Future events to implement
   // P2P_CONNECTION_REQUESTED: 'P2PConnectionRequested', // for now we always connect all lobby members

--- a/src/services/audio.ts
+++ b/src/services/audio.ts
@@ -1,7 +1,8 @@
 import { IFRAME_MESSAGE_TYPE } from "@wvdsh/api";
 import { type WavedashSDK } from "../index";
 import { WavedashManager } from "./manager";
-import { logger } from "../utils/logger";
+import { WavedashEvents } from "../events";
+import type { MuteChangedPayload } from "../types";
 
 /**
  * Set of WeakRefs — lets us iterate tracked elements without preventing GC.
@@ -81,7 +82,6 @@ export class AudioManager extends WavedashManager {
   private handleMute = (data: { isMuted: boolean }): void => {
     if (this._isMuted === data.isMuted) return;
     this._isMuted = data.isMuted;
-    logger.debug(`[AudioManager] muted=${this._isMuted}`);
 
     // Web Audio: short ramp avoids audible pops on instant 0↔1 jumps.
     // cancelScheduledValues clears any in-flight ramp from a recent toggle so
@@ -102,6 +102,12 @@ export class AudioManager extends WavedashManager {
         setMutedNative.call(el, this._isMuted ? true : intended);
       });
     }
+
+    // Notify game in case it needs to update in-game UI
+    this.sdk.gameEventManager.notifyGame(
+      WavedashEvents.MUTE_CHANGED,
+      { isMuted: this._isMuted } satisfies MuteChangedPayload
+    );
   };
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -258,6 +258,13 @@ export interface FullscreenChangedPayload {
   isFullscreen: boolean;
 }
 
+// --- Audio Events ---
+
+/** Payload for MuteChanged event - emitted when mute state flips */
+export interface MuteChangedPayload {
+  isMuted: boolean;
+}
+
 // =============================================================================
 // Event map: links each event name to its payload type so addEventListener,
 // removeEventListener, on, and off can infer the right CustomEvent / payload.
@@ -280,6 +287,7 @@ export type WavedashEventMap = {
   [WavedashEvents.BACKEND_DISCONNECTED]: BackendConnectionPayload;
   [WavedashEvents.BACKEND_RECONNECTING]: BackendConnectionPayload;
   [WavedashEvents.FULLSCREEN_CHANGED]: FullscreenChangedPayload;
+  [WavedashEvents.MUTE_CHANGED]: MuteChangedPayload;
 };
 
 // =============================================================================


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, additive SDK event surface; mute behavior is unchanged aside from notifying the engine.
> 
> **Overview**
> When the host toggles mute (iframe `MUTE_CHANGED`), the SDK now emits a **`MuteChanged`** engine event with `{ isMuted }`, matching how **`FullscreenChanged`** is surfaced so games can sync in-game audio UI.
> 
> Adds **`WavedashEvents.MUTE_CHANGED`**, **`MuteChangedPayload`**, and **`WavedashEventMap`** wiring; **`AudioManager.handleMute`** calls **`gameEventManager.notifyGame`** after applying Web Audio / HTML media mute. A trailing comma is added on **`FULLSCREEN_CHANGED`** in the events object.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcd32a1e66ca17d01bb632bc209099056264dada. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->