### PR TITLE
Toggle mute API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@wvdsh/sdk-js",
       "version": "1.3.15",
       "dependencies": {
-        "@wvdsh/api": "^0.1.28",
+        "@wvdsh/api": "^0.1.32",
         "convex": "^1.39.1",
         "lodash.throttle": "^4.1.1"
       },
@@ -1313,9 +1313,9 @@
       }
     },
     "node_modules/@wvdsh/api": {
-      "version": "0.1.28",
-      "resolved": "https://registry.npmjs.org/@wvdsh/api/-/api-0.1.28.tgz",
-      "integrity": "sha512-BYapb1x0I3Zc1ANuGCE9g6f2h3ttUmBBvVhoQ/1sv40YNck+JEf5XAqaxVH+bwTtiyBBF7X4vvRoXDeHFgXprg==",
+      "version": "0.1.32",
+      "resolved": "https://registry.npmjs.org/@wvdsh/api/-/api-0.1.32.tgz",
+      "integrity": "sha512-739HvUWbHdcdAqtGVeuksXf297Qb8MvpYc4bKXMONcK5j2cUXxtSnqOGARgCQWHabHig292rwKR4eTMoWRTLKg==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "typescript-eslint": "^8.52.0"
   },
   "dependencies": {
-    "@wvdsh/api": "^0.1.28",
+    "@wvdsh/api": "^0.1.32",
     "convex": "^1.39.1",
     "lodash.throttle": "^4.1.1"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -423,6 +423,35 @@ class WavedashSDK extends EventTarget {
     return this.fullscreenManager.toggleFullscreen();
   }
 
+  // =====
+  // Audio
+  // =====
+
+  /**
+   * Whether the game is currently muted. Mirrored from the Wavedash host page,
+   * which owns the mute control so its UI button and the game stay in sync.
+   */
+  isMuted(): boolean {
+    return this.audioManager.isMuted();
+  }
+
+  /**
+   * Ask the host to mute (true) or unmute (false). Resolves to `true` if the
+   * change was applied, `false` if it was rejected — the host won't let the
+   * game unmute when the user has muted from the Wavedash UI.
+   */
+  async requestMute(muted: boolean): Promise<boolean> {
+    return this.audioManager.requestMute(muted);
+  }
+
+  /**
+   * Toggle mute. Resolves to `true` if the change was applied, `false` if it
+   * was rejected (e.g. trying to unmute over an explicit user mute).
+   */
+  async toggleMute(): Promise<boolean> {
+    return this.audioManager.toggleMute();
+  }
+
   // ============
   // User methods
   // ============

--- a/src/services/audio.ts
+++ b/src/services/audio.ts
@@ -79,6 +79,33 @@ export class AudioManager extends WavedashManager {
     return this._isMuted;
   }
 
+  /**
+   * Ask the host to mute (true) or unmute (false). Resolves to `true` if the
+   * host applied the change, `false` otherwise — notably, the host rejects an
+   * unmute when the user muted the game from the Wavedash UI, so games can't
+   * override an explicit user mute. The resulting state arrives via the usual
+   * MUTE_CHANGED broadcast, so `isMuted()` updates independently of this result.
+   */
+  async requestMute(muted: boolean): Promise<boolean> {
+    const response = await this.sdk.iframeMessenger.requestFromParent(
+      IFRAME_MESSAGE_TYPE.SET_MUTE,
+      { muted }
+    );
+    return response.success;
+  }
+
+  /**
+   * Toggle mute. Like `requestMute`, the host may reject the unmute half of a
+   * toggle if the user muted from the Wavedash UI. Resolves to `true` if the
+   * host applied the change.
+   */
+  async toggleMute(): Promise<boolean> {
+    const response = await this.sdk.iframeMessenger.requestFromParent(
+      IFRAME_MESSAGE_TYPE.TOGGLE_MUTE
+    );
+    return response.success;
+  }
+
   private handleMute = (data: { isMuted: boolean }): void => {
     if (this._isMuted === data.isMuted) return;
     this._isMuted = data.isMuted;

--- a/src/services/leaderboards.ts
+++ b/src/services/leaderboards.ts
@@ -123,7 +123,12 @@ export class LeaderboardManager extends WavedashManager {
       this.updateCachedTotalEntries(leaderboardId, result.totalEntries);
     }
     return {
+      // Where your current leaderboard standing ranks
       ...result.entry,
+      // Where the submission itself ranks
+      submittedScore: result.submission.score,
+      submittedRank: result.submission.globalRank,
+      // User info
       userId: this.sdk.wavedashUser.id,
       username: this.sdk.wavedashUser.username,
       userAvatarUrl: this.sdk.wavedashUser.avatarUrl

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,6 +79,8 @@ export type UpsertedLeaderboardEntry = FunctionReturnType<
   userId: Id<"users">;
   username: string;
   userAvatarUrl?: string;
+  submittedScore: number;
+  submittedRank: number;
 };
 
 // Type helper to get event values as a union type


### PR DESCRIPTION
Mute API mirrors fullscreen API
Include submittedScore and submittedRank in uploadLeaderboardScore response

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive SDK APIs and response fields; mute behavior follows the existing fullscreen iframe pattern with no auth or data-model changes in this repo.
> 
> **Overview**
> Adds **host-synced mute controls** on the public SDK (`isMuted`, `requestMute`, `toggleMute`), matching the fullscreen pattern: games ask the parent via iframe messages (`SET_MUTE` / `TOGGLE_MUTE`), and the promise resolves to whether the host accepted the change (unmute can be rejected if the user muted from Wavedash UI).
> 
> **`uploadLeaderboardScore`** now returns **`submittedScore`** and **`submittedRank`** for the score just submitted, alongside the existing standing entry fields; types and **`@wvdsh/api`** are bumped to **^0.1.32** for the new message types and mutation shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f616fcac2977094d4ae880331f61d363bcd184e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->