### PR TITLE
Support in-game purchases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@wvdsh/sdk-js",
       "version": "1.3.16",
       "dependencies": {
-        "@wvdsh/api": "^0.1.32",
+        "@wvdsh/api": "^0.1.34",
         "convex": "^1.39.1",
         "lodash.throttle": "^4.1.1"
       },
@@ -1313,9 +1313,9 @@
       }
     },
     "node_modules/@wvdsh/api": {
-      "version": "0.1.32",
-      "resolved": "https://registry.npmjs.org/@wvdsh/api/-/api-0.1.32.tgz",
-      "integrity": "sha512-739HvUWbHdcdAqtGVeuksXf297Qb8MvpYc4bKXMONcK5j2cUXxtSnqOGARgCQWHabHig292rwKR4eTMoWRTLKg==",
+      "version": "0.1.34",
+      "resolved": "https://registry.npmjs.org/@wvdsh/api/-/api-0.1.34.tgz",
+      "integrity": "sha512-VtyDhHqSkh2PtPAQtqXNC/T/5RQyMOp4TXIY88zy3e1ZylkEGUd3eGdP2Y0U+KRpu0vdNqyvlrqQ/A8C2btMZg==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "typescript-eslint": "^8.52.0"
   },
   "dependencies": {
-    "@wvdsh/api": "^0.1.32",
+    "@wvdsh/api": "^0.1.34",
     "convex": "^1.39.1",
     "lodash.throttle": "^4.1.1"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1321,28 +1321,33 @@ class WavedashSDK extends EventTarget {
 
   /**
    * Returns true if the player owns the given paid content for this game.
-   * Local check against the gameplay JWT's `ents` claim — no network call.
-   * Pair with triggerPaywall() to drive your in-game purchase UI.
+   * Reads the `entitlements` claim from the gameplay JWT — this is a UX hint, not a
+   * security check. The play worker re-verifies the JWT signature and gates
+   * paid asset bytes on every request, so a tampered client return value
+   * doesn't actually unlock anything. Pair with triggerPaywall() to drive
+   * your in-game purchase UI.
    */
-  async userHasAccess(contentIdentifier: string): Promise<boolean> {
-    validateArgs(
+  async userHasAccess(
+    contentIdentifier: string
+  ): Promise<WavedashResponse<boolean>> {
+    return this.apiCall(
+      this.paidContentManager,
       "userHasAccess",
       [["contentIdentifier", vString]],
-      [contentIdentifier]
+      contentIdentifier
     );
-    return this.paidContentManager.userHasAccess(contentIdentifier);
   }
 
   /**
    * Trigger the Wavedash-rendered paywall flow for the given content. Resolves
-   * immediately with `{ purchased: true }` if the player already owns it;
-   * otherwise opens the modal and resolves once the user clicks BUY or CANCEL.
+   * immediately with `true` (data) if the player already owns it; otherwise
+   * opens the modal and resolves with whether the user clicked BUY or CANCEL.
    * After a successful purchase the JWT is refreshed automatically so a
    * subsequent userHasAccess() call reflects the new entitlement.
    */
   async triggerPaywall(
     contentIdentifier: string
-  ): Promise<WavedashResponse<{ purchased: boolean }>> {
+  ): Promise<WavedashResponse<boolean>> {
     return this.apiCall(
       this.paidContentManager,
       "triggerPaywall",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1322,20 +1322,32 @@ class WavedashSDK extends EventTarget {
   /**
    * Returns true if the player owns the given paid content for this game.
    * Reads the `entitlements` claim from the gameplay JWT — this is a UX hint, not a
-   * security check. The play worker re-verifies the JWT signature and gates
+   * security check. The builds server re-verifies the JWT signature and gates
    * paid asset bytes on every request, so a tampered client return value
    * doesn't actually unlock anything. Pair with triggerPaywall() to drive
-   * your in-game purchase UI.
+   * in-game UI.
    */
-  async userHasAccess_EXPERIMENTAL(
-    contentIdentifier: string
+  async hasUserPurchased_EXPERIMENTAL(
+    contentId: string
   ): Promise<WavedashResponse<boolean>> {
     return this.apiCall(
       this.paidContentManager,
-      "userHasAccess",
-      [["contentIdentifier", vString]],
-      contentIdentifier
+      "hasUserPurchased",
+      [["contentId", vString]],
+      contentId
     );
+  }
+
+  /**
+   * Returns the full list of paid-content IDs the player owns for this game.
+   * Reads the `entitlements` claim from the gameplay JWT — this is a UX hint,
+   * not a security check (see {@link hasUserPurchased_EXPERIMENTAL}). Useful
+   * for access gating multiple items at once without a call per content ID.
+   */
+  async getUserEntitlements_EXPERIMENTAL(): Promise<
+    WavedashResponse<string[]>
+  > {
+    return this.apiCall(this.paidContentManager, "getUserEntitlements", []);
   }
 
   /**
@@ -1343,7 +1355,7 @@ class WavedashSDK extends EventTarget {
    * immediately with data `true` if the player already owns it; otherwise
    * opens the modal and resolves with whether the user completed the purchase.
    * After a successful purchase the JWT is refreshed automatically so a
-   * subsequent resource fetch is authenticated with the new purchase, and userHasAccess
+   * subsequent resource fetch is authenticated with the new purchase, and hasUserPurchased
    * will return true if the purchase was successful.
    */
   async triggerPaywall_EXPERIMENTAL(

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { FullscreenManager } from "./services/fullscreen";
 import { OverlayManager } from "./services/overlay";
 import { AudioManager } from "./services/audio";
 import { FriendsManager } from "./services/friends";
+import { PaidContentManager } from "./services/paidContent";
 import { logger, LOG_LEVEL } from "./utils/logger";
 import { IFrameMessenger } from "./utils/iframeMessenger";
 import { SwMessenger } from "./utils/swMessenger";
@@ -123,6 +124,7 @@ class WavedashSDK extends EventTarget {
   fullscreenManager: FullscreenManager;
   overlayManager: OverlayManager;
   audioManager: AudioManager;
+  paidContentManager: PaidContentManager;
   private managers: WavedashManager[];
   private gameplayJwt: string | null = null;
   private gameplayJwtPromise: Promise<string> | null = null;
@@ -156,6 +158,7 @@ class WavedashSDK extends EventTarget {
     this.fullscreenManager = new FullscreenManager(this);
     this.overlayManager = new OverlayManager(this);
     this.audioManager = new AudioManager(this);
+    this.paidContentManager = new PaidContentManager(this);
 
     // Single source of truth for teardown — `destroy()` iterates this list.
     // Order matches construction so destroys happen in dependency order
@@ -172,7 +175,8 @@ class WavedashSDK extends EventTarget {
       this.gameEventManager,
       this.fullscreenManager,
       this.overlayManager,
-      this.audioManager
+      this.audioManager,
+      this.paidContentManager
     ];
 
     // Cache current user for avatar lookups
@@ -1311,6 +1315,42 @@ class WavedashSDK extends EventTarget {
     );
   }
 
+  // ============
+  // Paid content
+  // ============
+
+  /**
+   * Returns true if the player owns the given paid content for this game.
+   * Local check against the gameplay JWT's `ents` claim — no network call.
+   * Pair with triggerPaywall() to drive your in-game purchase UI.
+   */
+  async userHasAccess(contentIdentifier: string): Promise<boolean> {
+    validateArgs(
+      "userHasAccess",
+      [["contentIdentifier", vString]],
+      [contentIdentifier]
+    );
+    return this.paidContentManager.userHasAccess(contentIdentifier);
+  }
+
+  /**
+   * Trigger the Wavedash-rendered paywall flow for the given content. Resolves
+   * immediately with `{ purchased: true }` if the player already owns it;
+   * otherwise opens the modal and resolves once the user clicks BUY or CANCEL.
+   * After a successful purchase the JWT is refreshed automatically so a
+   * subsequent userHasAccess() call reflects the new entitlement.
+   */
+  async triggerPaywall(
+    contentIdentifier: string
+  ): Promise<WavedashResponse<{ purchased: boolean }>> {
+    return this.apiCall(
+      this.paidContentManager,
+      "triggerPaywall",
+      [["contentIdentifier", vString]],
+      contentIdentifier
+    );
+  }
+
   // ==============================
   // User Presence
   // ==============================
@@ -1493,8 +1533,8 @@ class WavedashSDK extends EventTarget {
    * already running (e.g. from Convex's initial setAuth). Use this anywhere
    * you need to authenticate a request outside of the Convex client.
    */
-  async ensureGameplayJwt(): Promise<string> {
-    return this.getAuthToken();
+  async ensureGameplayJwt(forceRefresh = false): Promise<string> {
+    return this.getAuthToken(forceRefresh);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1561,7 +1561,7 @@ class WavedashSDK extends EventTarget {
    * already running (e.g. from Convex's initial setAuth). Use this anywhere
    * you need to authenticate a request outside of the Convex client.
    */
-  async ensureGameplayJwt(forceRefresh = false): Promise<string> {
+  async ensureGameplayJwt(forceRefresh: boolean = false): Promise<string> {
     return this.getAuthToken(forceRefresh);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1504,8 +1504,8 @@ class WavedashSDK extends EventTarget {
    * Concurrent callers share one in-flight fetch. A forced refresh instead
    * serializes behind any in-flight fetch (it may predate the event that
    * required it, e.g. a purchase) and becomes the current promise; only the
-   * current promise pushes the result to the parent / service worker, so a
-   * superseded refresh can't broadcast a stale token.
+   * current promise notifies the parent, so a superseded refresh can't
+   * broadcast a stale token
    */
   private getAuthToken(forceRefresh = false): Promise<string> {
     if (!forceRefresh && this.gameplayJwt) {
@@ -1538,17 +1538,10 @@ class WavedashSDK extends EventTarget {
         // (each awaits `previous`), so tokens resolve in start order
         this.gameplayJwt = token;
         
-        // Push to the parent / service worker only from the current (latest)
-        // refresh to avoid chatter.
+        // Notify the parent (for /end-session) only from the latest refresh
         if (this.gameplayJwtPromise === promise) {
-          // Push to parent so it can handle /end-session on its own
           iframeMessenger.postToParent(IFRAME_MESSAGE_TYPE.GAMEPLAY_JWT_READY, {
             gameplayJwt: token
-          });
-          // Push to service worker so it can attach Bearer token
-          this.swMessenger.postToServiceWorker({
-            type: "embed.jwt-update",
-            payload: { gameplayJwt: token }
           });
         }
         return token;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,63 +1,63 @@
 import { ConvexClient } from "convex/browser";
-import { LobbyManager } from "./services/lobby";
-import { FileSystemManager } from "./services/fileSystem";
-import { UGCManager } from "./services/ugc";
-import { LeaderboardManager } from "./services/leaderboards";
-import { P2PManager } from "./services/p2p";
-import { StatsManager } from "./services/stats";
-import { HeartbeatManager } from "./services/heartbeat";
-import { GameEventManager } from "./services/gameEvents";
-import { FullscreenManager } from "./services/fullscreen";
-import { OverlayManager } from "./services/overlay";
-import { AudioManager } from "./services/audio";
-import { FriendsManager } from "./services/friends";
-import { PaidContentManager } from "./services/paidContent";
-import { logger, LOG_LEVEL } from "./utils/logger";
-import { IFrameMessenger } from "./utils/iframeMessenger";
-import { SwMessenger } from "./utils/swMessenger";
 import {
+  AvatarSize,
+  GAME_ENGINE,
+  LEADERBOARD_DISPLAY_TYPE,
+  LEADERBOARD_SORT_ORDER,
+  LOBBY_VISIBILITY,
   LobbyKickedReason,
   LobbyUserChangeType,
   P2PPacketDropReason,
-  AvatarSize,
-  LOBBY_VISIBILITY,
-  LEADERBOARD_SORT_ORDER,
-  LEADERBOARD_DISPLAY_TYPE,
   UGC_TYPE,
-  UGC_VISIBILITY,
-  GAME_ENGINE
+  UGC_VISIBILITY
 } from "./constants";
 import { WavedashEvents } from "./events";
-import type { WavedashEventMap } from "./types";
+import { AudioManager } from "./services/audio";
+import { FileSystemManager } from "./services/fileSystem";
+import { FriendsManager } from "./services/friends";
+import { FullscreenManager } from "./services/fullscreen";
+import { GameEventManager } from "./services/gameEvents";
+import { HeartbeatManager } from "./services/heartbeat";
+import { LeaderboardManager } from "./services/leaderboards";
+import { LobbyManager } from "./services/lobby";
 import type { WavedashManager } from "./services/manager";
+import { OverlayManager } from "./services/overlay";
+import { P2PManager } from "./services/p2p";
+import { PaidContentManager } from "./services/paidContent";
+import { StatsManager } from "./services/stats";
+import { UGCManager } from "./services/ugc";
+import type { WavedashEventMap } from "./types";
+import { IFrameMessenger } from "./utils/iframeMessenger";
+import { LOG_LEVEL, logger } from "./utils/logger";
+import { SwMessenger } from "./utils/swMessenger";
 
 // Create singleton instance for iframe messaging
 const iframeMessenger = new IFrameMessenger();
 
+import { IFRAME_MESSAGE_TYPE, SDKConfig, SDKUser, UrlParams } from "@wvdsh/api";
 import type {
-  Id,
-  LobbyVisibility,
-  LeaderboardSortOrder,
-  LeaderboardDisplayType,
-  WavedashConfig,
   EngineInstance,
+  Friend,
+  GameLaunchParams,
+  Id,
   Leaderboard,
+  LeaderboardDisplayType,
   LeaderboardEntries,
-  WavedashResponse,
-  UpsertedLeaderboardEntry,
+  LeaderboardSortOrder,
+  ListUGCItemsArgs,
+  Lobby,
+  LobbyUser,
+  LobbyVisibility,
+  P2PMessage,
+  PaginatedUGCItems,
+  RemoteFileMetadata,
   UGCType,
   UGCVisibility,
   UpdateUGCItemArgs,
-  PaginatedUGCItems,
-  ListUGCItemsArgs,
-  RemoteFileMetadata,
-  P2PMessage,
-  LobbyUser,
-  Lobby,
-  Friend,
-  GameLaunchParams
+  UpsertedLeaderboardEntry,
+  WavedashConfig,
+  WavedashResponse
 } from "./types";
-import { IFRAME_MESSAGE_TYPE, SDKConfig, SDKUser, UrlParams } from "@wvdsh/api";
 import { setParentOrigin } from "./utils/parentOrigin";
 import {
   type ArgSpec,
@@ -67,12 +67,12 @@ import {
   vId,
   vNull,
   vNumber,
+  vObject,
   vOptional,
   vRecord,
   vString,
   vUint8Array,
-  vUnion,
-  vObject
+  vUnion
 } from "./utils/validation";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -138,7 +138,7 @@ class WavedashSDK extends EventTarget {
       expectAuth: true
     });
     this.gameCloudId = sdkConfig.gameCloudId;
-    this.iframeMessenger = iframeMessenger;  // should be above getAuthToken so it can post to parent, don't move this
+    this.iframeMessenger = iframeMessenger; // should be above getAuthToken so it can post to parent, don't move this
     this.convexClient.setAuth(({ forceRefreshToken }) =>
       this.getAuthToken(forceRefreshToken)
     );
@@ -1327,7 +1327,7 @@ class WavedashSDK extends EventTarget {
    * doesn't actually unlock anything. Pair with triggerPaywall() to drive
    * your in-game purchase UI.
    */
-  async userHasAccess(
+  async userHasAccess_EXPERIMENTAL(
     contentIdentifier: string
   ): Promise<WavedashResponse<boolean>> {
     return this.apiCall(
@@ -1340,12 +1340,13 @@ class WavedashSDK extends EventTarget {
 
   /**
    * Trigger the Wavedash-rendered paywall flow for the given content. Resolves
-   * immediately with `true` (data) if the player already owns it; otherwise
-   * opens the modal and resolves with whether the user clicked BUY or CANCEL.
+   * immediately with data `true` if the player already owns it; otherwise
+   * opens the modal and resolves with whether the user completed the purchase.
    * After a successful purchase the JWT is refreshed automatically so a
-   * subsequent userHasAccess() call reflects the new entitlement.
+   * subsequent resource fetch is authenticated with the new purchase, and userHasAccess
+   * will return true if the purchase was successful.
    */
-  async triggerPaywall(
+  async triggerPaywall_EXPERIMENTAL(
     contentIdentifier: string
   ): Promise<WavedashResponse<boolean>> {
     return this.apiCall(
@@ -1364,7 +1365,7 @@ class WavedashSDK extends EventTarget {
    * Supported keys:
    *   `status`  — one-line activity shown as the primary line (e.g. "Traveling in a group")
    *   `details` — secondary context shown beneath the status (e.g. current zone or mode)
-   * 
+   *
    * Pass an empty dictionary to clear all presence fields.
    * @param data Presence fields to update.
    * @returns true if the presence was updated successfully

--- a/src/index.ts
+++ b/src/index.ts
@@ -1327,12 +1327,12 @@ class WavedashSDK extends EventTarget {
    * doesn't actually unlock anything. Pair with triggerPaywall() to drive
    * in-game UI.
    */
-  async hasUserPurchased_EXPERIMENTAL(
+  async isEntitled_EXPERIMENTAL(
     contentId: string
   ): Promise<WavedashResponse<boolean>> {
     return this.apiCall(
       this.paidContentManager,
-      "hasUserPurchased",
+      "isEntitled",
       [["contentId", vString]],
       contentId
     );
@@ -1341,13 +1341,13 @@ class WavedashSDK extends EventTarget {
   /**
    * Returns the full list of paid-content IDs the player owns for this game.
    * Reads the `entitlements` claim from the gameplay JWT — this is a UX hint,
-   * not a security check (see {@link hasUserPurchased_EXPERIMENTAL}). Useful
+   * not a security check (see {@link isEntitled_EXPERIMENTAL}). Useful
    * for access gating multiple items at once without a call per content ID.
    */
-  async getUserEntitlements_EXPERIMENTAL(): Promise<
+  async getEntitlements_EXPERIMENTAL(): Promise<
     WavedashResponse<string[]>
   > {
-    return this.apiCall(this.paidContentManager, "getUserEntitlements", []);
+    return this.apiCall(this.paidContentManager, "getEntitlements", []);
   }
 
   /**
@@ -1355,7 +1355,7 @@ class WavedashSDK extends EventTarget {
    * immediately with data `true` if the player already owns it; otherwise
    * opens the modal and resolves with whether the user completed the purchase.
    * After a successful purchase the JWT is refreshed automatically so a
-   * subsequent resource fetch is authenticated with the new purchase, and hasUserPurchased
+   * subsequent resource fetch is authenticated with the new purchase, and isEntitled
    * will return true if the purchase was successful.
    */
   async triggerPaywall_EXPERIMENTAL(
@@ -1497,17 +1497,15 @@ class WavedashSDK extends EventTarget {
   }
 
   /**
-   * Fetches (or returns cached) gameplay JWT. Callers outside of Convex's
-   * setAuth should use {@link ensureGameplayJwt} instead; this method is the
-   * fetcher wired into `ConvexClient.setAuth` and honors `forceRefresh` so the
-   * server can invalidate a stale token.
+   * Fetcher wired into `ConvexClient.setAuth`; other callers use
+   * {@link ensureGameplayJwt}. Same-origin POST to /auth/refresh, authenticated
+   * by the gameplaySession cookie.
    *
-   * Same-origin POST to /auth/refresh on the play domain — the
-   * gameplaySession cookie set by the play server during playKey exchange
-   * authenticates the request, so no cross-origin credentials handling needed.
-   *
-   * Concurrent callers share a single in-flight fetch to avoid duplicate
-   * refresh round-trips.
+   * Concurrent callers share one in-flight fetch. A forced refresh instead
+   * serializes behind any in-flight fetch (it may predate the event that
+   * required it, e.g. a purchase) and becomes the current promise; only the
+   * current promise pushes the result to the parent / service worker, so a
+   * superseded refresh can't broadcast a stale token.
    */
   private getAuthToken(forceRefresh = false): Promise<string> {
     if (!forceRefresh && this.gameplayJwt) {
@@ -1517,7 +1515,13 @@ class WavedashSDK extends EventTarget {
       return this.gameplayJwtPromise;
     }
 
-    const promise = (async () => {
+    // Serialize behind any in-flight refresh so we never run two /auth/refresh
+    // round-trips at once and the later-started one always resolves last.
+    const previous = this.gameplayJwtPromise;
+    const fetchToken = async (): Promise<string> => {
+      if (previous) {
+        await previous.catch(() => {});
+      }
       const response = await fetch("/auth/refresh", {
         method: "POST",
         credentials: "same-origin"
@@ -1525,22 +1529,35 @@ class WavedashSDK extends EventTarget {
       if (!response.ok) {
         throw new Error(`Failed to refresh gameplay token: ${response.status}`);
       }
-      this.gameplayJwt = await response.text();
-      // Push to parent so it can handle /end-session on its own
-      iframeMessenger.postToParent(IFRAME_MESSAGE_TYPE.GAMEPLAY_JWT_READY, {
-        gameplayJwt: this.gameplayJwt
+      return response.text();
+    };
+
+    const promise = fetchToken()
+      .then((token) => {
+        // Advance the in-memory cache unconditionally. Refreshes are serialized
+        // (each awaits `previous`), so tokens resolve in start order
+        this.gameplayJwt = token;
+        
+        // Push to the parent / service worker only from the current (latest)
+        // refresh to avoid chatter.
+        if (this.gameplayJwtPromise === promise) {
+          // Push to parent so it can handle /end-session on its own
+          iframeMessenger.postToParent(IFRAME_MESSAGE_TYPE.GAMEPLAY_JWT_READY, {
+            gameplayJwt: token
+          });
+          // Push to service worker so it can attach Bearer token
+          this.swMessenger.postToServiceWorker({
+            type: "embed.jwt-update",
+            payload: { gameplayJwt: token }
+          });
+        }
+        return token;
+      })
+      .finally(() => {
+        if (this.gameplayJwtPromise === promise) {
+          this.gameplayJwtPromise = null;
+        }
       });
-      // Push to service worker so it can attach Bearer token
-      this.swMessenger.postToServiceWorker({
-        type: "embed.jwt-update",
-        payload: { gameplayJwt: this.gameplayJwt }
-      });
-      return this.gameplayJwt;
-    })().finally(() => {
-      if (this.gameplayJwtPromise === promise) {
-        this.gameplayJwtPromise = null;
-      }
-    });
 
     this.gameplayJwtPromise = promise;
     return promise;

--- a/src/services/audio.ts
+++ b/src/services/audio.ts
@@ -1,8 +1,8 @@
 import { IFRAME_MESSAGE_TYPE } from "@wvdsh/api";
-import { type WavedashSDK } from "../index";
-import { WavedashManager } from "./manager";
 import { WavedashEvents } from "../events";
+import { type WavedashSDK } from "../index";
 import type { MuteChangedPayload } from "../types";
+import { WavedashManager } from "./manager";
 
 /**
  * Set of WeakRefs — lets us iterate tracked elements without preventing GC.
@@ -131,10 +131,9 @@ export class AudioManager extends WavedashManager {
     }
 
     // Notify game in case it needs to update in-game UI
-    this.sdk.gameEventManager.notifyGame(
-      WavedashEvents.MUTE_CHANGED,
-      { isMuted: this._isMuted } satisfies MuteChangedPayload
-    );
+    this.sdk.gameEventManager.notifyGame(WavedashEvents.MUTE_CHANGED, {
+      isMuted: this._isMuted
+    } satisfies MuteChangedPayload);
   };
 
   /**
@@ -166,7 +165,9 @@ export class AudioManager extends WavedashManager {
     };
     if (win.webkitAudioContext) {
       this.originalWebKitAudioContext = win.webkitAudioContext;
-      win.webkitAudioContext = this.shimAudioContextClass(win.webkitAudioContext);
+      win.webkitAudioContext = this.shimAudioContextClass(
+        win.webkitAudioContext
+      );
     }
 
     // 2. `new Audio()` — common pattern for detached one-shot SFX that never

--- a/src/services/paidContent.ts
+++ b/src/services/paidContent.ts
@@ -1,82 +1,65 @@
-import { api, IFRAME_MESSAGE_TYPE } from "@wvdsh/api";
+import { IFRAME_MESSAGE_TYPE } from "@wvdsh/api";
 import { WavedashManager } from "./manager";
 import { logger } from "../utils/logger";
 
 const PAYWALL_TIMEOUT_MS = 10 * 60 * 1000;
 
-interface PaywallOffer {
-  paidContentId: string;
-  contentIdentifier: string;
-  title: string;
-  message: string;
-  features: string[];
-  buttonLabel: string;
-  imageR2Key?: string;
-  priceCents: number;
-}
-
-function parseEntsFromJwt(jwt: string): string[] {
+/**
+ * Decode the gameplay JWT payload to read the `entitlements` claim. We don't
+ * verify the signature here — a hostile client can patch this function to
+ * return whatever it wants either way, so verifying locally adds bar but no
+ * real boundary. The play worker re-verifies the JWT signature on every
+ * paid-asset request — that's the actual security gate.
+ *
+ * UTF-8 safe: claims may carry arbitrary user/file paths (e.g. r2key).
+ */
+function decodeJwtPayload(jwt: string): Record<string, unknown> | null {
   try {
     const [, payloadB64] = jwt.split(".");
-    if (!payloadB64) return [];
+    if (!payloadB64) return null;
     const b64 = payloadB64.replace(/-/g, "+").replace(/_/g, "/");
     const padded = b64 + "===".slice((b64.length + 3) % 4);
-    const json = atob(padded);
-    const payload = JSON.parse(json) as { ents?: unknown };
-    if (Array.isArray(payload.ents)) {
-      return payload.ents.filter((e): e is string => typeof e === "string");
-    }
-    return [];
+    const bytes = Uint8Array.from(atob(padded), (c) => c.charCodeAt(0));
+    const json = new TextDecoder().decode(bytes);
+    return JSON.parse(json) as Record<string, unknown>;
   } catch (err) {
-    logger.warn("Failed to parse ents from gameplay JWT", err);
-    return [];
+    logger.warn("Failed to decode JWT payload", err);
+    return null;
   }
+}
+
+function readEntitlementsFromJwt(jwt: string): string[] {
+  const payload = decodeJwtPayload(jwt);
+  const entitlements = payload?.entitlements;
+  if (!Array.isArray(entitlements)) return [];
+  return entitlements.filter((e): e is string => typeof e === "string");
 }
 
 export class PaidContentManager extends WavedashManager {
   async userHasAccess(contentIdentifier: string): Promise<boolean> {
     const jwt = await this.sdk.ensureGameplayJwt();
-    return parseEntsFromJwt(jwt).includes(contentIdentifier);
+    return readEntitlementsFromJwt(jwt).includes(contentIdentifier);
   }
 
-  async triggerPaywall(
-    contentIdentifier: string
-  ): Promise<{ purchased: boolean }> {
+  async triggerPaywall(contentIdentifier: string): Promise<boolean> {
     // Short-circuit when the player is already entitled — never show the modal
     // for already-purchased content. Game flows can call triggerPaywall freely.
-    if (await this.userHasAccess(contentIdentifier)) {
-      return { purchased: true };
-    }
+    if (await this.userHasAccess(contentIdentifier)) return true;
 
-    let offer: PaywallOffer;
-    try {
-      offer = (await this.sdk.convexClient.query(api.sdk.paidContent.getOffer, {
-        contentIdentifier
-      })) as PaywallOffer;
-    } catch (error) {
-      logger.error("Failed to fetch paywall offer", error);
-      return { purchased: false };
-    }
-
+    // The SDK only knows the contentIdentifier — parent (mainsite) fetches the
+    // offer, displays the modal, and runs the purchase mutation. We just wait
+    // for the response.
     const response = await this.sdk.iframeMessenger.requestFromParent(
       IFRAME_MESSAGE_TYPE.TRIGGER_PAYWALL,
-      { offer },
+      { contentIdentifier },
       PAYWALL_TIMEOUT_MS
     );
-    if (!response.purchased) return { purchased: false };
+    if (!response.purchased) return false;
 
-    try {
-      await this.sdk.convexClient.mutation(
-        api.sdk.paidContent.mockFulfillPurchase,
-        { paidContentId: offer.paidContentId }
-      );
-    } catch (error) {
-      logger.error("Mock fulfill failed", error);
-      return { purchased: false };
-    }
-
-    // Force a JWT refresh so the new `ents` entry is live before we return
+    // Refresh through /auth/refresh so the play worker's session cookies stay
+    // in sync — accepting a JWT directly from the parent would leave the
+    // cookie fallback path on a stale token.
     await this.sdk.ensureGameplayJwt(true);
-    return { purchased: true };
+    return true;
   }
 }

--- a/src/services/paidContent.ts
+++ b/src/services/paidContent.ts
@@ -5,10 +5,11 @@ import { logger } from "../utils/logger";
 const PAYWALL_TIMEOUT_MS = 10 * 60 * 1000;
 
 /**
- * Decode the gameplay JWT payload to read the `entitlements` claim. We don't
- * verify the signature here — a hostile client can patch this function to
- * return whatever it wants either way, so verifying locally adds bar but no
- * real boundary. The play worker re-verifies the JWT signature on every
+ * Decode the gameplay JWT payload to read the `ents` claim (short on the wire
+ * to keep token size down; surfaced as `entitlements` everywhere else). We
+ * don't verify the signature here — a hostile client can patch this function
+ * to return whatever it wants either way, so verifying locally adds bar but
+ * no real boundary. The play worker re-verifies the JWT signature on every
  * paid-asset request — that's the actual security gate.
  *
  * UTF-8 safe: claims may carry arbitrary user/file paths (e.g. r2key).
@@ -30,9 +31,9 @@ function decodeJwtPayload(jwt: string): Record<string, unknown> | null {
 
 function readEntitlementsFromJwt(jwt: string): string[] {
   const payload = decodeJwtPayload(jwt);
-  const entitlements = payload?.entitlements;
-  if (!Array.isArray(entitlements)) return [];
-  return entitlements.filter((e): e is string => typeof e === "string");
+  const ents = payload?.ents;
+  if (!Array.isArray(ents)) return [];
+  return ents.filter((e): e is string => typeof e === "string");
 }
 
 export class PaidContentManager extends WavedashManager {

--- a/src/services/paidContent.ts
+++ b/src/services/paidContent.ts
@@ -37,12 +37,12 @@ function readEntitlementsFromJwt(jwt: string): string[] {
 }
 
 export class PaidContentManager extends WavedashManager {
-  async hasUserPurchased(contentId: string): Promise<boolean> {
+  async isEntitled(contentId: string): Promise<boolean> {
     const jwt = await this.sdk.ensureGameplayJwt();
     return readEntitlementsFromJwt(jwt).includes(contentId);
   }
 
-  async getUserEntitlements(): Promise<string[]> {
+  async getEntitlements(): Promise<string[]> {
     const jwt = await this.sdk.ensureGameplayJwt();
     return readEntitlementsFromJwt(jwt);
   }
@@ -50,7 +50,7 @@ export class PaidContentManager extends WavedashManager {
   async triggerPaywall(contentIdentifier: string): Promise<boolean> {
     // Short-circuit when the player is already entitled — never show the modal
     // for already-purchased content. Game flows can call triggerPaywall freely.
-    if (await this.hasUserPurchased(contentIdentifier)) return true;
+    if (await this.isEntitled(contentIdentifier)) return true;
 
     // The SDK only knows the contentIdentifier — parent (mainsite) fetches the
     // offer, displays the modal, and runs the purchase mutation. We just wait

--- a/src/services/paidContent.ts
+++ b/src/services/paidContent.ts
@@ -37,15 +37,20 @@ function readEntitlementsFromJwt(jwt: string): string[] {
 }
 
 export class PaidContentManager extends WavedashManager {
-  async userHasAccess(contentIdentifier: string): Promise<boolean> {
+  async hasUserPurchased(contentId: string): Promise<boolean> {
     const jwt = await this.sdk.ensureGameplayJwt();
-    return readEntitlementsFromJwt(jwt).includes(contentIdentifier);
+    return readEntitlementsFromJwt(jwt).includes(contentId);
+  }
+
+  async getUserEntitlements(): Promise<string[]> {
+    const jwt = await this.sdk.ensureGameplayJwt();
+    return readEntitlementsFromJwt(jwt);
   }
 
   async triggerPaywall(contentIdentifier: string): Promise<boolean> {
     // Short-circuit when the player is already entitled — never show the modal
     // for already-purchased content. Game flows can call triggerPaywall freely.
-    if (await this.userHasAccess(contentIdentifier)) return true;
+    if (await this.hasUserPurchased(contentIdentifier)) return true;
 
     // The SDK only knows the contentIdentifier — parent (mainsite) fetches the
     // offer, displays the modal, and runs the purchase mutation. We just wait
@@ -57,9 +62,7 @@ export class PaidContentManager extends WavedashManager {
     );
     if (!response.purchased) return false;
 
-    // Refresh through /auth/refresh so the play worker's session cookies stay
-    // in sync — accepting a JWT directly from the parent would leave the
-    // cookie fallback path on a stale token.
+    // Force refresh JWT so the latest entitlements are reflected
     await this.sdk.ensureGameplayJwt(true);
     return true;
   }

--- a/src/services/paidContent.ts
+++ b/src/services/paidContent.ts
@@ -1,0 +1,82 @@
+import { api, IFRAME_MESSAGE_TYPE } from "@wvdsh/api";
+import { WavedashManager } from "./manager";
+import { logger } from "../utils/logger";
+
+const PAYWALL_TIMEOUT_MS = 10 * 60 * 1000;
+
+interface PaywallOffer {
+  paidContentId: string;
+  contentIdentifier: string;
+  title: string;
+  message: string;
+  features: string[];
+  buttonLabel: string;
+  imageR2Key?: string;
+  priceCents: number;
+}
+
+function parseEntsFromJwt(jwt: string): string[] {
+  try {
+    const [, payloadB64] = jwt.split(".");
+    if (!payloadB64) return [];
+    const b64 = payloadB64.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = b64 + "===".slice((b64.length + 3) % 4);
+    const json = atob(padded);
+    const payload = JSON.parse(json) as { ents?: unknown };
+    if (Array.isArray(payload.ents)) {
+      return payload.ents.filter((e): e is string => typeof e === "string");
+    }
+    return [];
+  } catch (err) {
+    logger.warn("Failed to parse ents from gameplay JWT", err);
+    return [];
+  }
+}
+
+export class PaidContentManager extends WavedashManager {
+  async userHasAccess(contentIdentifier: string): Promise<boolean> {
+    const jwt = await this.sdk.ensureGameplayJwt();
+    return parseEntsFromJwt(jwt).includes(contentIdentifier);
+  }
+
+  async triggerPaywall(
+    contentIdentifier: string
+  ): Promise<{ purchased: boolean }> {
+    // Short-circuit when the player is already entitled — never show the modal
+    // for already-purchased content. Game flows can call triggerPaywall freely.
+    if (await this.userHasAccess(contentIdentifier)) {
+      return { purchased: true };
+    }
+
+    let offer: PaywallOffer;
+    try {
+      offer = (await this.sdk.convexClient.query(api.sdk.paidContent.getOffer, {
+        contentIdentifier
+      })) as PaywallOffer;
+    } catch (error) {
+      logger.error("Failed to fetch paywall offer", error);
+      return { purchased: false };
+    }
+
+    const response = await this.sdk.iframeMessenger.requestFromParent(
+      IFRAME_MESSAGE_TYPE.TRIGGER_PAYWALL,
+      { offer },
+      PAYWALL_TIMEOUT_MS
+    );
+    if (!response.purchased) return { purchased: false };
+
+    try {
+      await this.sdk.convexClient.mutation(
+        api.sdk.paidContent.mockFulfillPurchase,
+        { paidContentId: offer.paidContentId }
+      );
+    } catch (error) {
+      logger.error("Mock fulfill failed", error);
+      return { purchased: false };
+    }
+
+    // Force a JWT refresh so the new `ents` entry is live before we return
+    await this.sdk.ensureGameplayJwt(true);
+    return { purchased: true };
+  }
+}

--- a/src/utils/iframeMessenger.ts
+++ b/src/utils/iframeMessenger.ts
@@ -105,7 +105,8 @@ export class IFrameMessenger {
 
   async requestFromParent<T extends keyof IFrameEventPayloadMap>(
     requestType: T,
-    data?: Record<string, unknown>
+    data?: Record<string, unknown>,
+    timeoutMs: number = RESPONSE_TIMEOUT_MS
   ): Promise<IFrameEventPayloadMap[T]> {
     return new Promise((resolve, reject) => {
       const parentOrigin = getParentOrigin();
@@ -120,10 +121,10 @@ export class IFrameMessenger {
         this.pendingRequests.delete(requestId);
         reject(
           new Error(
-            `${requestType} request timed out after ${RESPONSE_TIMEOUT_MS}ms`
+            `${requestType} request timed out after ${timeoutMs}ms`
           )
         );
-      }, RESPONSE_TIMEOUT_MS);
+      }, timeoutMs);
 
       this.pendingRequests.set(requestId, {
         resolve: resolve as (data: IFrameResponseValue) => void,


### PR DESCRIPTION
`hasUserPurchased_EXPERIMENTAL` - has the user already purchased a given contentId (unsafe UX hint)
`getUserEntitlements_EXPERIMENTAL` - get all contentIds the user has already purchased (unsafe UX hint)
`triggerPaywall_EXPERIMENTAL` - trigger the Wavedash paywall checkout flow for the given contentId (unsafe UX hint)

The real security gate is on the server that serves build files. A malicious client can tamper with their local JWT to "hack" their own game UI, but they will never be served bytes for files they haven't purchased

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches gameplay JWT refresh and parent messaging used by Convex auth and post-purchase entitlement updates; client entitlement reads are intentionally non-authoritative but purchase flows depend on refresh ordering.
> 
> **Overview**
> Adds **experimental in-game paid content** support by wiring a new `PaidContentManager` into the SDK and exposing `isEntitled_EXPERIMENTAL`, `getEntitlements_EXPERIMENTAL`, and `triggerPaywall_EXPERIMENTAL`. Entitlement checks decode the `ents` claim from the cached gameplay JWT (documented as a UX hint only); `triggerPaywall` asks the parent frame via `IFRAME_MESSAGE_TYPE.TRIGGER_PAYWALL` with a **10-minute** timeout, then **force-refreshes** the JWT on successful purchase.
> 
> **Gameplay JWT refresh** is reworked: concurrent `/auth/refresh` calls serialize, forced refresh chains behind any in-flight refresh, the in-memory token updates from each completed fetch, and **only the latest refresh** posts `GAMEPLAY_JWT_READY` to the parent (avoids broadcasting stale tokens after purchase). `ensureGameplayJwt` now accepts `forceRefresh`.
> 
> Bumps **`@wvdsh/api`** to `^0.1.34`. Minor import/formatting tweaks in `audio.ts`; `requestFromParent` gains an optional per-call timeout (default unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89afdad42a6f03c5e9524b34aa198290f2f09d6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->