### PR TITLE
Fix mute for off DOM elems

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,13 @@ import { SwMessenger } from "./utils/swMessenger";
 // Create singleton instance for iframe messaging
 const iframeMessenger = new IFrameMessenger();
 
-import { IFRAME_MESSAGE_TYPE, SDKConfig, SDKUser, UrlParams } from "@wvdsh/api";
+import {
+  IFRAME_MESSAGE_TYPE,
+  SDKConfig,
+  SDKUser,
+  UrlParams,
+  SERVICE_WORKER_MESSAGE_TYPE
+} from "@wvdsh/api";
 import type {
   EngineInstance,
   Friend,
@@ -1344,9 +1350,7 @@ class WavedashSDK extends EventTarget {
    * not a security check (see {@link isEntitled_EXPERIMENTAL}). Useful
    * for access gating multiple items at once without a call per content ID.
    */
-  async getEntitlements_EXPERIMENTAL(): Promise<
-    WavedashResponse<string[]>
-  > {
+  async getEntitlements_EXPERIMENTAL(): Promise<WavedashResponse<string[]>> {
     return this.apiCall(this.paidContentManager, "getEntitlements", []);
   }
 
@@ -1537,7 +1541,7 @@ class WavedashSDK extends EventTarget {
         // Advance the in-memory cache unconditionally. Refreshes are serialized
         // (each awaits `previous`), so tokens resolve in start order
         this.gameplayJwt = token;
-        
+
         // Notify the parent (for /end-session) only from the latest refresh
         if (this.gameplayJwtPromise === promise) {
           iframeMessenger.postToParent(IFRAME_MESSAGE_TYPE.GAMEPLAY_JWT_READY, {
@@ -1583,14 +1587,14 @@ class WavedashSDK extends EventTarget {
   }
 
   /**
-   * Respond to the service worker's `embed.creds-request` with the SDK's
+   * Respond to the service worker's creds request with the SDK's
    * current gameplay JWT. The SW asks when it wakes from termination with no
    * in-memory or IDB credentials (e.g. Safari ITP storage decay) — we're the
    * fastest live source. JWT only; sessionToken is owned by the SW + cookies.
    */
   private setupSwCredsListener(): void {
     this.swMessenger.addEventListener(
-      "embed.creds-request",
+      SERVICE_WORKER_MESSAGE_TYPE.EMBED_CREDS_REQUEST,
       async (_payload, reply) => {
         let jwt: string;
         try {
@@ -1600,7 +1604,7 @@ class WavedashSDK extends EventTarget {
           return;
         }
         reply({
-          type: "embed.creds-response",
+          type: SERVICE_WORKER_MESSAGE_TYPE.EMBED_CREDS_RESPONSE,
           payload: { gameplayJwt: jwt }
         });
       }

--- a/src/services/audio.ts
+++ b/src/services/audio.ts
@@ -43,11 +43,18 @@ class WeakRefSet<T extends object> {
  *
  * HTML Media (`<audio>`/`<video>`): override `HTMLMediaElement.prototype.muted`
  * to record the game's intended state, but write `true` to the underlying element
- * whenever the SDK is muted. Tracked elements come from three sources:
+ * whenever the SDK is muted. Tracked elements come from five sources:
  *  1. Pre-existing DOM media (`querySelectorAll`)
  *  2. `new Audio()` constructor shim (covers detached SFX)
  *  3. MutationObserver for any media added to the DOM later (covers innerHTML,
  *     framework rendering, createElement + append, etc.)
+ *  4. `document.createElement('audio'|'video')` shim — covers media created and
+ *     kept OFF the DOM (e.g. a PIXI/GDevelop intro video), which the three DOM
+ *     sources above never observe.
+ *  5. `HTMLMediaElement.prototype.play()` shim — the universal point where an
+ *     element starts producing audio. Catches anything driven purely via
+ *     `.play()`/`.volume` (never assigning `.muted`, never entering the DOM),
+ *     force-muting it before playback begins regardless of how it was created.
  */
 export class AudioManager extends WavedashManager {
   private _isMuted = false;
@@ -64,6 +71,8 @@ export class AudioManager extends WavedashManager {
   private originalWebKitAudioContext: typeof AudioContext | null = null;
   private originalAudio: typeof Audio | null = null;
   private originalMutedDescriptor: PropertyDescriptor | null = null;
+  private originalCreateElement: typeof document.createElement | null = null;
+  private originalPlay: typeof HTMLMediaElement.prototype.play | null = null;
   private mutationObserver: MutationObserver | null = null;
 
   constructor(sdk: WavedashSDK) {
@@ -211,6 +220,23 @@ export class AudioManager extends WavedashManager {
         childList: true,
         subtree: true
       });
+
+      // 3c. `document.createElement('audio'|'video')` — covers media created and
+      //     kept OFF the DOM (e.g. a PIXI/GDevelop intro video driven via
+      //     .volume/.play()), which querySelectorAll and the MutationObserver
+      //     never see. Track at creation so the current/next mute state applies.
+      const originalCreateElement = document.createElement;
+      this.originalCreateElement = originalCreateElement;
+      ((manager) => {
+        document.createElement = function (
+          tagName: string,
+          options?: ElementCreationOptions
+        ) {
+          const el = originalCreateElement.call(document, tagName, options);
+          if (el instanceof HTMLMediaElement) manager.trackElement(el);
+          return el;
+        } as typeof document.createElement;
+      })(this);
     }
 
     // 4. Override HTMLMediaElement.prototype.muted so the game sees its own
@@ -235,6 +261,20 @@ export class AudioManager extends WavedashManager {
         });
       })(this);
     }
+
+    // 5. `HTMLMediaElement.prototype.play()` — the universal point where a media
+    //    element starts producing audio. Tracking here force-mutes (when the SDK
+    //    is muted) before playback begins, catching off-DOM elements driven via
+    //    .play()/.volume that never assign .muted — the one path the DOM-based
+    //    sources and the muted setter all miss.
+    const originalPlay = HTMLMediaElement.prototype.play;
+    this.originalPlay = originalPlay;
+    ((manager) => {
+      HTMLMediaElement.prototype.play = function (this: HTMLMediaElement) {
+        manager.trackElement(this);
+        return originalPlay.call(this);
+      };
+    })(this);
   }
 
   private shimAudioContextClass(
@@ -292,6 +332,14 @@ export class AudioManager extends WavedashManager {
       if (this.originalAudio) {
         window.Audio = this.originalAudio;
       }
+    }
+
+    if (this.originalCreateElement && typeof document !== "undefined") {
+      document.createElement = this.originalCreateElement;
+    }
+
+    if (this.originalPlay) {
+      HTMLMediaElement.prototype.play = this.originalPlay;
     }
 
     if (this.originalMutedDescriptor) {

--- a/src/services/audio.ts
+++ b/src/services/audio.ts
@@ -35,7 +35,7 @@ class WeakRefSet<T extends object> {
  * AudioManager
  *
  * Mutes & unmutes the game in response to MUTE_CHANGED iframe messages, without
- * the game needing to know anything about it.
+ * the game needing to handle it itself.
  *
  * Web Audio: subclass `AudioContext` so `ctx.destination` resolves to a master
  * GainNode that we control. The master gain wires to the real native destination,
@@ -43,18 +43,17 @@ class WeakRefSet<T extends object> {
  *
  * HTML Media (`<audio>`/`<video>`): override `HTMLMediaElement.prototype.muted`
  * to record the game's intended state, but write `true` to the underlying element
- * whenever the SDK is muted. Tracked elements come from five sources:
+ * whenever the SDK is muted. Tracked elements come from four sources:
  *  1. Pre-existing DOM media (`querySelectorAll`)
  *  2. `new Audio()` constructor shim (covers detached SFX)
  *  3. MutationObserver for any media added to the DOM later (covers innerHTML,
  *     framework rendering, createElement + append, etc.)
- *  4. `document.createElement('audio'|'video')` shim — covers media created and
- *     kept OFF the DOM (e.g. a PIXI/GDevelop intro video), which the three DOM
- *     sources above never observe.
- *  5. `HTMLMediaElement.prototype.play()` shim — the universal point where an
+ *  4. `HTMLMediaElement.prototype.play()` shim — the universal point where an
  *     element starts producing audio. Catches anything driven purely via
- *     `.play()`/`.volume` (never assigning `.muted`, never entering the DOM),
- *     force-muting it before playback begins regardless of how it was created.
+ *     `.play()`/`.volume` (never assigning `.muted`, never entering the DOM,
+ *     e.g. a PIXI/GDevelop intro video), force-muting it before playback begins
+ *     regardless of how it was created — the one path the DOM-based sources and
+ *     the `muted` setter all miss.
  */
 export class AudioManager extends WavedashManager {
   private _isMuted = false;
@@ -71,7 +70,6 @@ export class AudioManager extends WavedashManager {
   private originalWebKitAudioContext: typeof AudioContext | null = null;
   private originalAudio: typeof Audio | null = null;
   private originalMutedDescriptor: PropertyDescriptor | null = null;
-  private originalCreateElement: typeof document.createElement | null = null;
   private originalPlay: typeof HTMLMediaElement.prototype.play | null = null;
   private mutationObserver: MutationObserver | null = null;
 
@@ -220,23 +218,6 @@ export class AudioManager extends WavedashManager {
         childList: true,
         subtree: true
       });
-
-      // 3c. `document.createElement('audio'|'video')` — covers media created and
-      //     kept OFF the DOM (e.g. a PIXI/GDevelop intro video driven via
-      //     .volume/.play()), which querySelectorAll and the MutationObserver
-      //     never see. Track at creation so the current/next mute state applies.
-      const originalCreateElement = document.createElement;
-      this.originalCreateElement = originalCreateElement;
-      ((manager) => {
-        document.createElement = function (
-          tagName: string,
-          options?: ElementCreationOptions
-        ) {
-          const el = originalCreateElement.call(document, tagName, options);
-          if (el instanceof HTMLMediaElement) manager.trackElement(el);
-          return el;
-        } as typeof document.createElement;
-      })(this);
     }
 
     // 4. Override HTMLMediaElement.prototype.muted so the game sees its own
@@ -332,10 +313,6 @@ export class AudioManager extends WavedashManager {
       if (this.originalAudio) {
         window.Audio = this.originalAudio;
       }
-    }
-
-    if (this.originalCreateElement && typeof document !== "undefined") {
-      document.createElement = this.originalCreateElement;
     }
 
     if (this.originalPlay) {

--- a/src/services/p2p.ts
+++ b/src/services/p2p.ts
@@ -1272,7 +1272,6 @@ export class P2PManager extends WavedashManager {
           toUserId: toUserId,
           messageType: message.type,
           data: message.data as Record<string, string | number | null>
-
         }
       );
       logger.debug("Sent signaling message:", message.type);

--- a/src/utils/iframeMessenger.ts
+++ b/src/utils/iframeMessenger.ts
@@ -120,9 +120,7 @@ export class IFrameMessenger {
       const timeout = setTimeout(() => {
         this.pendingRequests.delete(requestId);
         reject(
-          new Error(
-            `${requestType} request timed out after ${timeoutMs}ms`
-          )
+          new Error(`${requestType} request timed out after ${timeoutMs}ms`)
         );
       }, timeoutMs);
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -58,7 +58,9 @@ export const vUint8Array: Validator<Uint8Array> = (value, path) => {
   return value;
 };
 
-export const vRecord: Validator<Record<string, string | number | boolean | null>> = (value, path) => {
+export const vRecord: Validator<
+  Record<string, string | number | boolean | null>
+> = (value, path) => {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new Error(
       `${path}: expected plain object, got ${describeValue(value)}`


### PR DESCRIPTION
Audio manager now patches .play() function to apply mute to any elements that were added off-DOM

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Global `play()` prototype patching affects all media in the embed iframe; behavior is intentional but could interact oddly with games that rely on pre-play side effects.
> 
> **Overview**
> **Host mute now applies to off-DOM HTML media** that never hit the existing DOM/`new Audio()`/`muted` tracking paths—common for engine intro videos driven only via `.play()` and volume.
> 
> `AudioManager` wraps `HTMLMediaElement.prototype.play()` so every playback calls `trackElement()` first, applying the SDK mute state before audio starts. The original `play` is restored on teardown like the other shims.
> 
> Separately, service-worker credential handshake in the main SDK entry uses shared `SERVICE_WORKER_MESSAGE_TYPE` constants instead of raw string message types. Remaining diff hunks are formatting only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34cdfb2b5ae3f5eb21c528d89f9aaadf42acae0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->