### PR TITLE
SDK adds ?caller=wavedash to the auth refresh request

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ import {
   SDKConfig,
   SDKUser,
   UrlParams,
+  PlayRouteCaller,
   SERVICE_WORKER_MESSAGE_TYPE
 } from "@wvdsh/api";
 import type {
@@ -1526,7 +1527,11 @@ class WavedashSDK extends EventTarget {
       if (previous) {
         await previous.catch(() => {});
       }
-      const response = await fetch("/auth/refresh", {
+      const refreshQuery = new URLSearchParams({
+        [UrlParams.Caller]: PlayRouteCaller.Wavedash
+      });
+      const refreshPath = `/auth/refresh?${refreshQuery.toString()}`;
+      const response = await fetch(refreshPath, {
         method: "POST",
         credentials: "same-origin"
       });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small change to the refresh URL only; auth flow and cookies stay the same, with behavior depending on the server honoring the new query param.
> 
> **Overview**
> Gameplay JWT refresh requests from the SDK now include **`?caller=wavedash`** on **`POST /auth/refresh`**, built with `UrlParams.Caller` and `PlayRouteCaller` from `@wvdsh/api`.
> 
> That path is used by Convex `setAuth` and **`ensureGameplayJwt()`**, so every serialized refresh in the game iframe identifies the caller to the backend without changing method, credentials, or refresh serialization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit def0502c666d40b082ba22b169487d82d64900d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->