### PR TITLE
Paid content quality of life features

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@wvdsh/sdk-js",
       "version": "1.3.19",
       "dependencies": {
-        "@wvdsh/api": "^0.1.34",
+        "@wvdsh/api": "^0.1.36",
         "convex": "^1.39.1",
         "lodash.throttle": "^4.1.1"
       },
@@ -1313,9 +1313,9 @@
       }
     },
     "node_modules/@wvdsh/api": {
-      "version": "0.1.34",
-      "resolved": "https://registry.npmjs.org/@wvdsh/api/-/api-0.1.34.tgz",
-      "integrity": "sha512-VtyDhHqSkh2PtPAQtqXNC/T/5RQyMOp4TXIY88zy3e1ZylkEGUd3eGdP2Y0U+KRpu0vdNqyvlrqQ/A8C2btMZg==",
+      "version": "0.1.36",
+      "resolved": "https://registry.npmjs.org/@wvdsh/api/-/api-0.1.36.tgz",
+      "integrity": "sha512-WgquIs/Qgkd5fRa1iKf1gyaM0iSoXfRXUx5OPrSNomWwe01kEQhorZLsxdO+f7iHYQ9yQ59dOV7jhUEqGlzj9g==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "typescript-eslint": "^8.52.0"
   },
   "dependencies": {
-    "@wvdsh/api": "^0.1.34",
+    "@wvdsh/api": "^0.1.36",
     "convex": "^1.39.1",
     "lodash.throttle": "^4.1.1"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -392,10 +392,6 @@ class WavedashSDK extends EventTarget {
     this.gameFinishedLoading = true;
     this.heartbeatManager.start();
     iframeMessenger.postToParent(IFRAME_MESSAGE_TYPE.LOADING_COMPLETE, {});
-
-    setTimeout(async () => {
-      await this.triggerPaywall_EXPERIMENTAL("full-version");
-    }, 2000);
   }
 
   get gameLoaded(): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -394,6 +394,10 @@ class WavedashSDK extends EventTarget {
     iframeMessenger.postToParent(IFRAME_MESSAGE_TYPE.LOADING_COMPLETE, {});
     // Take focus when loading is complete
     this.overlayManager.takeFocus();
+
+    setTimeout(async () => {
+      await this.triggerPaywall_EXPERIMENTAL("full-version");
+    }, 2000);
   }
 
   get gameLoaded(): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -392,8 +392,6 @@ class WavedashSDK extends EventTarget {
     this.gameFinishedLoading = true;
     this.heartbeatManager.start();
     iframeMessenger.postToParent(IFRAME_MESSAGE_TYPE.LOADING_COMPLETE, {});
-    // Take focus when loading is complete
-    this.overlayManager.takeFocus();
 
     setTimeout(async () => {
       await this.triggerPaywall_EXPERIMENTAL("full-version");

--- a/src/services/overlay.ts
+++ b/src/services/overlay.ts
@@ -24,14 +24,13 @@ export class OverlayManager extends WavedashManager {
 
     this.sdk.iframeMessenger.addEventListener(
       IFRAME_MESSAGE_TYPE.TAKE_FOCUS,
-      () => takeFocus()
+      takeFocus
     );
 
-    /** @TODO uncomment once @wvdsh/api is published with latest IFRAME_MESSAGE_TYPE */
-    // this.sdk.iframeMessenger.addEventListener(
-    //   IFRAME_MESSAGE_TYPE.OVERLAY_CHANGED,
-    //   ({ isOpen }) => this.setOpen(isOpen)
-    // );
+    this.sdk.iframeMessenger.addEventListener(
+      IFRAME_MESSAGE_TYPE.OVERLAY_CHANGED,
+      ({ isOpen }) => this.setOpen(isOpen)
+    );
 
     if (typeof window !== "undefined") {
       window.addEventListener("keydown", this.handleKeyDown);
@@ -60,4 +59,12 @@ export class OverlayManager extends WavedashManager {
       this.toggleOverlay();
     }
   };
+
+  destroy(): void {
+    this.restorePointerLock?.();
+    this.restorePointerLock = undefined;
+    if (typeof window !== "undefined") {
+      window.removeEventListener("keydown", this.handleKeyDown);
+    }
+  }
 }

--- a/src/services/overlay.ts
+++ b/src/services/overlay.ts
@@ -1,5 +1,7 @@
 import { IFRAME_MESSAGE_TYPE } from "@wvdsh/api";
 import { type WavedashSDK } from "../index";
+import { takeFocus } from "../utils/focus";
+import { suspendPointerLock } from "../utils/pointerLock";
 import { WavedashManager } from "./manager";
 
 /**
@@ -8,22 +10,40 @@ import { WavedashManager } from "./manager";
  * Owns the iframe ↔ parent interactions for the Wavedash overlay UI:
  * - Shift+Tab inside the iframe toggles the overlay on the host page
  *   (the host owns the overlay, so we postMessage up).
- * - When the parent closes the overlay it sends TAKE_FOCUS so keyboard
- *   input goes back to the game; we walk the DOM for a focusable target.
- * - `takeFocus()` is also called after load completes so the game starts
- *   with keyboard focus without the player clicking first.
+ * - When the parent closes the overlay it sends TAKE_FOCUS, which hands
+ *   keyboard focus back to the game (see `takeFocus`).
+ * - While the overlay is open we suspend pointer lock (the host broadcasts
+ *   OVERLAY_CHANGED) so a game can't hold/re-grab the cursor behind it.
  */
 export class OverlayManager extends WavedashManager {
+  // Restores native pointer lock; set while the overlay is open.
+  private restorePointerLock: (() => void) | undefined;
+
   constructor(sdk: WavedashSDK) {
     super(sdk);
 
     this.sdk.iframeMessenger.addEventListener(
       IFRAME_MESSAGE_TYPE.TAKE_FOCUS,
-      () => this.takeFocus()
+      () => takeFocus()
     );
+
+    /** @TODO uncomment once @wvdsh/api is published with latest IFRAME_MESSAGE_TYPE */
+    // this.sdk.iframeMessenger.addEventListener(
+    //   IFRAME_MESSAGE_TYPE.OVERLAY_CHANGED,
+    //   ({ isOpen }) => this.setOpen(isOpen)
+    // );
 
     if (typeof window !== "undefined") {
       window.addEventListener("keydown", this.handleKeyDown);
+    }
+  }
+
+  private setOpen(open: boolean): void {
+    if (open) {
+      this.restorePointerLock ??= suspendPointerLock();
+    } else {
+      this.restorePointerLock?.();
+      this.restorePointerLock = undefined;
     }
   }
 
@@ -32,23 +52,6 @@ export class OverlayManager extends WavedashManager {
       IFRAME_MESSAGE_TYPE.TOGGLE_OVERLAY,
       {}
     );
-  }
-
-  takeFocus(): void {
-    if (typeof document === "undefined") return;
-
-    const gameFocusTargets =
-      document.getElementsByClassName("game-focus-target");
-    if (gameFocusTargets.length > 0) {
-      (gameFocusTargets[0] as HTMLElement).focus();
-      return;
-    }
-
-    // Fallback: focus the first focusable element (canvas, input, button, etc.)
-    const focusableElement = document.querySelector(
-      "canvas, input, button, [tabindex]:not([tabindex='-1'])"
-    ) as HTMLElement | null;
-    focusableElement?.focus();
   }
 
   private handleKeyDown = (event: KeyboardEvent) => {

--- a/src/services/paidContent.ts
+++ b/src/services/paidContent.ts
@@ -58,10 +58,7 @@ export class PaidContentManager extends WavedashManager {
 
     // Don't let the game open a second paywall over an in-progress one.
     if (this.paywallOpen) {
-      logger.warn(
-        `triggerPaywall(${contentIdentifier}) ignored: a paywall is already open`
-      );
-      return false;
+      throw new Error('Paywall already in progress');
     }
     this.paywallOpen = true;
 
@@ -86,6 +83,10 @@ export class PaidContentManager extends WavedashManager {
     // Force refresh JWT so the latest entitlements are reflected
     await this.sdk.ensureGameplayJwt(true);
     return true;
+  }
+
+  isPaywallOpen(): boolean {
+    return this.paywallOpen;
   }
 
   destroy(): void {

--- a/src/services/paidContent.ts
+++ b/src/services/paidContent.ts
@@ -38,6 +38,9 @@ function readEntitlementsFromJwt(jwt: string): string[] {
 }
 
 export class PaidContentManager extends WavedashManager {
+  private paywallOpen = false;
+  private restorePointerLock: (() => void) | undefined;
+
   async isEntitled(contentId: string): Promise<boolean> {
     const jwt = await this.sdk.ensureGameplayJwt();
     return readEntitlementsFromJwt(jwt).includes(contentId);
@@ -53,9 +56,18 @@ export class PaidContentManager extends WavedashManager {
     // for already-purchased content. Game flows can call triggerPaywall freely.
     if (await this.isEntitled(contentIdentifier)) return true;
 
-    // Keep the cursor free while the modal is open (some games re-grab pointer
-    // lock every frame). Restored once the parent responds.
-    const restorePointerLock = suspendPointerLock();
+    // Don't let the game open a second paywall over an in-progress one.
+    if (this.paywallOpen) {
+      logger.warn(
+        `triggerPaywall(${contentIdentifier}) ignored: a paywall is already open`
+      );
+      return false;
+    }
+    this.paywallOpen = true;
+
+    // Keep the cursor free while the modal is open
+    // Restored once the parent responds (or on destroy).
+    this.restorePointerLock = suspendPointerLock();
 
     let response;
     try {
@@ -65,12 +77,19 @@ export class PaidContentManager extends WavedashManager {
         PAYWALL_TIMEOUT_MS
       );
     } finally {
-      restorePointerLock();
+      this.restorePointerLock?.();
+      this.restorePointerLock = undefined;
+      this.paywallOpen = false;
     }
     if (!response.purchased) return false;
 
     // Force refresh JWT so the latest entitlements are reflected
     await this.sdk.ensureGameplayJwt(true);
     return true;
+  }
+
+  destroy(): void {
+    this.restorePointerLock?.();
+    this.restorePointerLock = undefined;
   }
 }

--- a/src/services/paidContent.ts
+++ b/src/services/paidContent.ts
@@ -1,6 +1,7 @@
 import { IFRAME_MESSAGE_TYPE } from "@wvdsh/api";
 import { WavedashManager } from "./manager";
 import { logger } from "../utils/logger";
+import { suspendPointerLock } from "../utils/pointerLock";
 
 const PAYWALL_TIMEOUT_MS = 10 * 60 * 1000;
 
@@ -52,14 +53,20 @@ export class PaidContentManager extends WavedashManager {
     // for already-purchased content. Game flows can call triggerPaywall freely.
     if (await this.isEntitled(contentIdentifier)) return true;
 
-    // The SDK only knows the contentIdentifier — parent (mainsite) fetches the
-    // offer, displays the modal, and runs the purchase mutation. We just wait
-    // for the response.
-    const response = await this.sdk.iframeMessenger.requestFromParent(
-      IFRAME_MESSAGE_TYPE.TRIGGER_PAYWALL,
-      { contentIdentifier },
-      PAYWALL_TIMEOUT_MS
-    );
+    // Keep the cursor free while the modal is open (some games re-grab pointer
+    // lock every frame). Restored once the parent responds.
+    const restorePointerLock = suspendPointerLock();
+
+    let response;
+    try {
+      response = await this.sdk.iframeMessenger.requestFromParent(
+        IFRAME_MESSAGE_TYPE.TRIGGER_PAYWALL,
+        { contentIdentifier },
+        PAYWALL_TIMEOUT_MS
+      );
+    } finally {
+      restorePointerLock();
+    }
     if (!response.purchased) return false;
 
     // Force refresh JWT so the latest entitlements are reflected

--- a/src/utils/focus.ts
+++ b/src/utils/focus.ts
@@ -1,0 +1,20 @@
+/**
+ * Move keyboard focus to the game so it receives input without the player
+ * clicking first — used after load completes and when the overlay hands focus
+ * back. Prefers an explicit `.game-focus-target`, otherwise the first focusable
+ * element (canvas, input, button, …).
+ */
+export function takeFocus(): void {
+  if (typeof document === "undefined") return;
+
+  const gameFocusTargets = document.getElementsByClassName("game-focus-target");
+  if (gameFocusTargets.length > 0) {
+    (gameFocusTargets[0] as HTMLElement).focus();
+    return;
+  }
+
+  const focusableElement = document.querySelector(
+    "canvas, input, button, [tabindex]:not([tabindex='-1'])"
+  ) as HTMLElement | null;
+  focusableElement?.focus();
+}

--- a/src/utils/pointerLock.ts
+++ b/src/utils/pointerLock.ts
@@ -7,9 +7,12 @@
  * Call the returned dispose fn to restore the native method.
  */
 
-const hasDom = typeof Element !== "undefined" && typeof document !== "undefined";
+const hasDom =
+  typeof Element !== "undefined" && typeof document !== "undefined";
 // Captured at module load, before anything could have replaced it.
-const nativeRequestPointerLock = hasDom ? Element.prototype.requestPointerLock : undefined;
+const nativeRequestPointerLock = hasDom
+  ? Element.prototype.requestPointerLock
+  : undefined;
 
 // Ref-counted so overlapping suspensions don't restore the native method early.
 let depth = 0;
@@ -30,6 +33,7 @@ export function suspendPointerLock(): () => void {
   return () => {
     if (disposed) return;
     disposed = true;
-    if (--depth === 0) Element.prototype.requestPointerLock = nativeRequestPointerLock;
+    if (--depth === 0)
+      Element.prototype.requestPointerLock = nativeRequestPointerLock;
   };
 }

--- a/src/utils/pointerLock.ts
+++ b/src/utils/pointerLock.ts
@@ -1,0 +1,35 @@
+/**
+ * Pointer lock suspension for overlays shown over a game.
+ *
+ * A game that re-requests pointer lock every frame would steal the cursor back
+ * from an overlay. Suspending shims requestPointerLock
+ * to a no-op so those calls can't reacquire the lock, and exits any active lock.
+ * Call the returned dispose fn to restore the native method.
+ */
+
+const hasDom = typeof Element !== "undefined" && typeof document !== "undefined";
+// Captured at module load, before anything could have replaced it.
+const nativeRequestPointerLock = hasDom ? Element.prototype.requestPointerLock : undefined;
+
+// Ref-counted so overlapping suspensions don't restore the native method early.
+let depth = 0;
+
+export function suspendPointerLock(): () => void {
+  if (!hasDom || !nativeRequestPointerLock) return () => {};
+
+  if (++depth === 1) {
+    // Resolved promise keeps modern (Promise-returning) callers happy; legacy
+    // void callers ignore the return value.
+    Element.prototype.requestPointerLock = function () {
+      return Promise.resolve();
+    } as typeof Element.prototype.requestPointerLock;
+  }
+  document.exitPointerLock();
+
+  let disposed = false;
+  return () => {
+    if (disposed) return;
+    disposed = true;
+    if (--depth === 0) Element.prototype.requestPointerLock = nativeRequestPointerLock;
+  };
+}


### PR DESCRIPTION
Better behavior around pointer lock / focus coming in and out of overlay/fullscreen/paid content modal
One paid content modal up at a time

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Monkey-patches `requestPointerLock` and changes load-time focus and paywall concurrency (throws on overlapping `triggerPaywall`), which can affect input behavior in embedded games.
> 
> **Overview**
> Improves **pointer lock** and **focus** behavior when the Wavedash overlay or paid-content paywall sits on top of the game, and bumps **`@wvdsh/api`** to `^0.1.36` for the new **`OVERLAY_CHANGED`** iframe message.
> 
> Adds **`suspendPointerLock()`** (ref-counted shim on `Element.prototype.requestPointerLock` plus `document.exitPointerLock`) and uses it while the overlay is open (driven by **`OVERLAY_CHANGED`**) and for the duration of **`triggerPaywall`**. **`takeFocus`** moves to **`src/utils/focus.ts`**; overlay **`TAKE_FOCUS`** uses that helper. **`loadComplete()`** no longer calls **`takeFocus`** automatically.
> 
> **Paid content:** concurrent **`triggerPaywall`** calls throw **`Paywall already in progress`**; **`isPaywallOpen()`** and **`destroy()`** cleanup are added on overlay and paid-content managers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4bba7b637fca5cdb86fe11a5e855c0c70062f73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->