### PR TITLE
Recording gameplay video

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import type { WavedashManager } from "./services/manager";
 import { OverlayManager } from "./services/overlay";
 import { P2PManager } from "./services/p2p";
 import { PaidContentManager } from "./services/paidContent";
+import { ScreenCaptureManager } from "./services/screenCapture";
 import { StatsManager } from "./services/stats";
 import { UGCManager } from "./services/ugc";
 import type { WavedashEventMap } from "./types";
@@ -131,6 +132,7 @@ class WavedashSDK extends EventTarget {
   fullscreenManager: FullscreenManager;
   overlayManager: OverlayManager;
   audioManager: AudioManager;
+  screenCaptureManager: ScreenCaptureManager;
   paidContentManager: PaidContentManager;
   private managers: WavedashManager[];
   private gameplayJwt: string | null = null;
@@ -165,6 +167,8 @@ class WavedashSDK extends EventTarget {
     this.fullscreenManager = new FullscreenManager(this);
     this.overlayManager = new OverlayManager(this);
     this.audioManager = new AudioManager(this);
+    // Depends on audioManager for the capture audio tap.
+    this.screenCaptureManager = new ScreenCaptureManager(this);
     this.paidContentManager = new PaidContentManager(this);
 
     // Single source of truth for teardown — `destroy()` iterates this list.
@@ -183,6 +187,7 @@ class WavedashSDK extends EventTarget {
       this.fullscreenManager,
       this.overlayManager,
       this.audioManager,
+      this.screenCaptureManager,
       this.paidContentManager
     ];
 

--- a/src/services/audio.ts
+++ b/src/services/audio.ts
@@ -75,6 +75,11 @@ export class AudioManager extends WavedashManager {
     number
   >();
 
+  // Media elements already rerouted through Web Audio for capture. The
+  // reroute (createMediaElementSource) is permanent per element, so we must
+  // never attempt it twice — the second call throws InvalidStateError.
+  private capturedElements = new WeakSet<HTMLMediaElement>();
+
   // Originals (restored on destroy)
   private originalAudioContext: typeof AudioContext | null = null;
   private originalWebKitAudioContext: typeof AudioContext | null = null;
@@ -123,6 +128,108 @@ export class AudioManager extends WavedashManager {
       IFRAME_MESSAGE_TYPE.TOGGLE_MUTE
     );
     return response.success;
+  }
+
+  /**
+   * Build a MediaStream audio tap of everything the game plays, for gameplay
+   * capture (see ScreenCaptureManager). Returns the tap's audio tracks plus a
+   * `dispose()` that tears down the capture-only graph edges.
+   *
+   * Everything already funnels through the per-context master GainNodes this
+   * manager owns, so capture is just: master gain → MediaStreamDestination.
+   * Multiple contexts are mixed into one destination on a "host" context,
+   * bridging the others across via MediaStreamSource nodes (Web Audio nodes
+   * can't connect across contexts directly).
+   *
+   * HTML media elements are rerouted into the host context's master gain via
+   * createMediaElementSource. That reroute is permanent for the life of the
+   * element (the Web Audio spec offers no undo), but it's transparent: output
+   * still flows master gain → real destination, and both mute paths (native
+   * `muted` + master-gain ramp) keep working. Cross-origin media without CORS
+   * headers will tap as silence — same limitation as any Web Audio capture.
+   *
+   * Because the recording rides the master gains, captured audio respects the
+   * user's mute state — matching what they actually hear.
+   */
+  createCaptureTap(): {
+    tracks: MediaStreamTrack[];
+    dispose: () => void;
+  } | null {
+    if (typeof window === "undefined") return null;
+
+    // No game AudioContext yet? Create one (routed through our shim, so it
+    // self-registers in `contexts`) — but only if there are media elements
+    // worth tapping; otherwise there's simply no audio to capture.
+    if (this.contexts.size === 0) {
+      let hasMedia = false;
+      this.elements.forEach(() => {
+        hasMedia = true;
+      });
+      if (!hasMedia || !window.AudioContext) return null;
+      try {
+        void new window.AudioContext();
+      } catch {
+        return null;
+      }
+    }
+
+    const entries = [...this.contexts.entries()];
+    const hostEntry = entries[entries.length - 1];
+    if (!hostEntry) return null;
+    const [hostCtx, hostGain] = hostEntry;
+
+    // Autoplay policy may have left contexts suspended; a capture request
+    // implies a user gesture happened upstream, so nudge them awake.
+    for (const [ctx] of entries) {
+      if (ctx.state === "suspended") {
+        ctx.resume().catch(() => {});
+      }
+    }
+
+    const captureDest = hostCtx.createMediaStreamDestination();
+    const cleanups: (() => void)[] = [];
+
+    for (const [ctx, gain] of entries) {
+      if (ctx === hostCtx) {
+        gain.connect(captureDest);
+        cleanups.push(() => gain.disconnect(captureDest));
+      } else {
+        const bridgeDest = ctx.createMediaStreamDestination();
+        gain.connect(bridgeDest);
+        const bridgeSrc = hostCtx.createMediaStreamSource(bridgeDest.stream);
+        bridgeSrc.connect(captureDest);
+        cleanups.push(() => {
+          gain.disconnect(bridgeDest);
+          bridgeSrc.disconnect(captureDest);
+        });
+      }
+    }
+
+    // Reroute tracked HTML media into the host master gain so it lands in
+    // the capture mix (and stays audible through master → real destination).
+    this.elements.forEach((el) => {
+      if (this.capturedElements.has(el)) return;
+      try {
+        const src = hostCtx.createMediaElementSource(el);
+        src.connect(hostGain);
+        this.capturedElements.add(el);
+      } catch {
+        // Element already claimed by another context, or CORS-restricted.
+      }
+    });
+
+    return {
+      tracks: captureDest.stream.getAudioTracks(),
+      dispose: () => {
+        for (const cleanup of cleanups) {
+          try {
+            cleanup();
+          } catch {
+            // Context may have been closed by the game mid-recording.
+          }
+        }
+      }
+    };
   }
 
   private handleMute = (data: { isMuted: boolean }): void => {

--- a/src/services/screenCapture.ts
+++ b/src/services/screenCapture.ts
@@ -1,0 +1,335 @@
+import { type WavedashSDK } from "../index";
+import type { IFrameMessenger } from "../utils/iframeMessenger";
+import { logger } from "../utils/logger";
+import { WavedashManager } from "./manager";
+
+/**
+ * Iframe message types for gameplay capture.
+ * TODO: fold these into IFRAME_MESSAGE_TYPE in @wvdsh/api once the host-side
+ * support ships; the casts below go away with it.
+ */
+export const SCREEN_CAPTURE_MESSAGE_TYPE = {
+  /**
+   * Parent → SDK: desired recording state, `{ isRecording, fps? }`. Broadcast
+   * like MUTE_CHANGED/FULLSCREEN_CHANGED — we start/stop capture to match,
+   * and a broadcast that already matches our state is a no-op.
+   */
+  RECORDING_CHANGED: "RecordingChanged",
+  /**
+   * SDK → Parent: recording result. On success carries the recording Blob
+   * (`{ success: true, blob, mimeType, width, height, durationMs }`),
+   * on failure `{ success: false, error }`. The Blob rides postMessage's
+   * structured clone, which hands over a reference to the same immutable
+   * backing data — not a byte-by-byte copy — so this is cheap even for a
+   * long clip.
+   */
+  RECORDING_COMPLETE: "RecordingComplete"
+} as const;
+
+// The IFrameMessenger is typed against the published IFrameEventPayloadMap,
+// which doesn't know about these message types yet (see TODO above).
+type IFrameMessageType = Parameters<IFrameMessenger["addEventListener"]>[0];
+type IFrameMessageListener = Parameters<IFrameMessenger["addEventListener"]>[1];
+type ParentMessageType = Parameters<IFrameMessenger["postToParent"]>[0];
+
+interface RecordingChangedMessage {
+  isRecording: boolean;
+  fps?: number;
+}
+
+interface ActiveRecording {
+  recorder: MediaRecorder;
+  chunks: Blob[];
+  stream: MediaStream;
+  mimeType: string | null;
+  canvas: HTMLCanvasElement;
+  audioTap: { tracks: MediaStreamTrack[]; dispose: () => void } | null;
+  startedAt: number;
+}
+
+const DEFAULT_FPS = 60;
+/** Ask the recorder to flush a chunk every second so memory stays bounded. */
+const TIMESLICE_MS = 1_000;
+/** ~13 MB/min — comfortably above what canvas content needs at 1080p60. */
+const VIDEO_BITS_PER_SECOND = 14_000_000;
+
+const RENDERING_CONTEXT_TYPES = new Set([
+  "2d",
+  "webgl",
+  "webgl2",
+  "webgpu",
+  "experimental-webgl"
+]);
+
+// Preference order: H.264+AAC in MP4 first — same instant, transcode-free
+// pipeline, but the file is shareable everywhere (QuickTime, iOS, X/Twitter,
+// iMessage), which VP9 WebM is not. Chrome 126+, Edge, and Safari all mux MP4
+// natively in MediaRecorder; Firefox doesn't, so it walks down to WebM.
+const MIME_CANDIDATES = [
+  'video/mp4;codecs="avc1.42E01E,mp4a.40.2"',
+  "video/mp4",
+  "video/webm;codecs=vp9,opus",
+  "video/webm;codecs=vp9",
+  "video/webm;codecs=vp8,opus",
+  "video/webm"
+];
+
+function pickMimeType(): string | null {
+  if (
+    typeof MediaRecorder === "undefined" ||
+    typeof MediaRecorder.isTypeSupported !== "function"
+  ) {
+    return null;
+  }
+  for (const mime of MIME_CANDIDATES) {
+    if (MediaRecorder.isTypeSupported(mime)) return mime;
+  }
+  return null;
+}
+
+/**
+ * ScreenCaptureManager
+ *
+ * Records gameplay clips from inside the iframe — no getDisplayMedia
+ * permission prompt, no picker, nothing but the game in frame. The parent
+ * drives it over postMessage:
+ *
+ *   RecordingChanged isRecording:true → grab the game's canvas via
+ *   `canvas.captureStream()`, mix in the game's audio through AudioManager's
+ *   capture tap, and feed a MediaRecorder. The parent owns recording
+ *   duration — the SDK records until RecordingChanged isRecording:false
+ *   arrives, then posts the resulting Blob back as RecordingComplete.
+ *
+ * Canvas discovery mirrors the audio shims' philosophy: wrap
+ * `HTMLCanvasElement.prototype.getContext` to see every canvas the game
+ * renders to (including offscreen/detached ones at creation time), then pick
+ * the largest connected one when recording starts. A DOM query is the
+ * fallback for canvases created before the SDK loaded.
+ */
+export class ScreenCaptureManager extends WavedashManager {
+  private canvases: HTMLCanvasElement[] = [];
+  private active: ActiveRecording | null = null;
+  private originalGetContext:
+    | typeof HTMLCanvasElement.prototype.getContext
+    | null = null;
+
+  constructor(sdk: WavedashSDK) {
+    super(sdk);
+    this.installCanvasTracking();
+    this.sdk.iframeMessenger.addEventListener(
+      SCREEN_CAPTURE_MESSAGE_TYPE.RECORDING_CHANGED as IFrameMessageType,
+      this.handleRecordingChanged as IFrameMessageListener
+    );
+  }
+
+  isRecording(): boolean {
+    return this.active !== null;
+  }
+
+  private handleRecordingChanged = (data: RecordingChangedMessage): void => {
+    // State broadcast, not a command — ignore no-op flips (e.g. the parent
+    // confirming a stop we initiated ourselves after a capture error).
+    if (data.isRecording === this.isRecording()) return;
+    if (data.isRecording) {
+      this.start(data);
+    } else {
+      void this.stop();
+    }
+  };
+
+  private start(options: RecordingChangedMessage): void {
+    const canvas = this.pickCanvas();
+    if (!canvas) {
+      this.postFailure("No game canvas found.");
+      return;
+    }
+
+    const fps =
+      typeof options.fps === "number" && Number.isFinite(options.fps)
+        ? Math.min(Math.max(options.fps, 1), 60)
+        : DEFAULT_FPS;
+
+    let stream: MediaStream;
+    try {
+      stream = canvas.captureStream(fps);
+    } catch (error) {
+      this.postFailure(
+        `canvas.captureStream failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+      return;
+    }
+
+    // Audio is best-effort — a silent clip beats no clip.
+    let audioTap: ActiveRecording["audioTap"] = null;
+    try {
+      audioTap = this.sdk.audioManager.createCaptureTap();
+      if (audioTap) {
+        for (const track of audioTap.tracks) stream.addTrack(track);
+      }
+    } catch (error) {
+      logger.warn("Screen capture: audio tap unavailable", error);
+      audioTap = null;
+    }
+
+    const mimeType = pickMimeType();
+    let recorder: MediaRecorder;
+    try {
+      recorder = new MediaRecorder(stream, {
+        ...(mimeType ? { mimeType } : {}),
+        videoBitsPerSecond: VIDEO_BITS_PER_SECOND
+      });
+    } catch (error) {
+      for (const track of stream.getTracks()) track.stop();
+      audioTap?.dispose();
+      this.postFailure(
+        `MediaRecorder failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+      return;
+    }
+
+    const chunks: Blob[] = [];
+    recorder.ondataavailable = (event: BlobEvent) => {
+      if (event.data && event.data.size > 0) chunks.push(event.data);
+    };
+    recorder.onerror = (event: Event) => {
+      logger.error("Screen capture: recorder error", event);
+      void this.stop();
+    };
+
+    recorder.start(TIMESLICE_MS);
+    this.active = {
+      recorder,
+      chunks,
+      stream,
+      mimeType,
+      canvas,
+      audioTap,
+      startedAt: Date.now()
+    };
+    logger.info(
+      `Screen capture: recording started ${canvas.width}x${canvas.height} @ ${fps}fps`,
+      mimeType
+    );
+  }
+
+  private async stop(): Promise<void> {
+    const active = this.active;
+    if (!active) return;
+    this.active = null;
+
+    // Wait for the recorder to flush its final chunk before assembling.
+    await new Promise<void>((resolve) => {
+      if (active.recorder.state === "inactive") {
+        resolve();
+        return;
+      }
+      active.recorder.onstop = () => resolve();
+      try {
+        active.recorder.stop();
+      } catch {
+        resolve();
+      }
+    });
+
+    for (const track of active.stream.getTracks()) track.stop();
+    active.audioTap?.dispose();
+
+    const blob = new Blob(
+      active.chunks,
+      active.mimeType ? { type: active.mimeType } : undefined
+    );
+    const durationMs = Date.now() - active.startedAt;
+    logger.info(
+      `Screen capture: recording finished, ${blob.size} bytes over ${durationMs}ms`
+    );
+
+    this.postToParent({
+      success: true,
+      blob,
+      mimeType: active.mimeType ?? blob.type,
+      width: active.canvas.width,
+      height: active.canvas.height,
+      durationMs
+    });
+  }
+
+  private postFailure(error: string): void {
+    logger.warn(`Screen capture: ${error}`);
+    this.postToParent({ success: false, error });
+  }
+
+  private postToParent(data: Record<string, unknown>): void {
+    this.sdk.iframeMessenger.postToParent(
+      SCREEN_CAPTURE_MESSAGE_TYPE.RECORDING_COMPLETE as ParentMessageType,
+      data
+    );
+  }
+
+  /**
+   * Largest connected tracked canvas wins — games often allocate small
+   * scratch canvases for text measurement or sprite baking, while the main
+   * render target dominates the viewport.
+   */
+  private pickCanvas(): HTMLCanvasElement | null {
+    let best: HTMLCanvasElement | null = null;
+    let bestArea = 0;
+    for (const canvas of this.canvases) {
+      if (!canvas.isConnected) continue;
+      const area = (canvas.width || 0) * (canvas.height || 0);
+      if (area > bestArea) {
+        bestArea = area;
+        best = canvas;
+      }
+    }
+    // Canvases that got their context before the SDK loaded never hit the
+    // getContext shim; fall back to whatever is in the DOM.
+    return best ?? document.querySelector("canvas");
+  }
+
+  private installCanvasTracking(): void {
+    if (typeof HTMLCanvasElement === "undefined") return;
+    const original = HTMLCanvasElement.prototype.getContext;
+    this.originalGetContext = original;
+    ((manager) => {
+      HTMLCanvasElement.prototype.getContext = function (
+        this: HTMLCanvasElement,
+        ...args: [string, unknown?]
+      ) {
+        const ctx = (
+          original as (
+            this: HTMLCanvasElement,
+            ...a: [string, unknown?]
+          ) => RenderingContext | null
+        ).apply(this, args);
+        const type = args[0];
+        if (ctx && typeof type === "string") {
+          if (
+            RENDERING_CONTEXT_TYPES.has(type.toLowerCase()) &&
+            !manager.canvases.includes(this)
+          ) {
+            manager.canvases.push(this);
+          }
+        }
+        return ctx;
+      } as typeof HTMLCanvasElement.prototype.getContext;
+    })(this);
+  }
+
+  override destroy(): void {
+    this.sdk.iframeMessenger.removeEventListener(
+      SCREEN_CAPTURE_MESSAGE_TYPE.RECORDING_CHANGED as IFrameMessageType,
+      this.handleRecordingChanged as IFrameMessageListener
+    );
+
+    // Best-effort: flush an in-flight recording to the parent on teardown.
+    void this.stop();
+
+    if (this.originalGetContext) {
+      HTMLCanvasElement.prototype.getContext = this.originalGetContext;
+      this.originalGetContext = null;
+    }
+    this.canvases = [];
+
+    super.destroy();
+  }
+}

--- a/src/utils/iframeMessenger.ts
+++ b/src/utils/iframeMessenger.ts
@@ -95,7 +95,8 @@ export class IFrameMessenger {
 
   postToParent(
     requestType: (typeof IFRAME_MESSAGE_TYPE)[keyof typeof IFRAME_MESSAGE_TYPE],
-    data: Record<string, string | number | boolean>
+    // Any structured-cloneable value is fine here (e.g. Blobs for capture).
+    data: Record<string, unknown>
   ): boolean {
     const parentOrigin = getParentOrigin();
     if (typeof window === "undefined" || !parentOrigin) return false;


### PR DESCRIPTION
ScreenCaptureManager
Captures only the main canvas using `canvas.captureStream`, ignores any HTML elements the game might be rendering
Returns captured blob to parent frame

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces global `HTMLCanvasElement.getContext` shimming and permanent Web Audio media-element reroutes for capture; failures are mostly isolated but could affect edge-case games during recording.
> 
> **Overview**
> Adds **in-iframe gameplay recording** driven by the parent via `RecordingChanged` / `RecordingComplete` postMessage (no `getDisplayMedia`).
> 
> **`ScreenCaptureManager`** picks the largest connected game canvas (`getContext` shim + DOM fallback), records with `canvas.captureStream()` and **`MediaRecorder`** (MP4/H.264 when supported, else WebM), and returns the clip blob plus metadata to the parent when recording stops.
> 
> **`AudioManager.createCaptureTap()`** mixes all shimmed Web Audio master gains (and tracked `<audio>`/`<video>` via `createMediaElementSource`) into capture tracks that respect the user mute state.
> 
> SDK wiring registers the manager after `AudioManager` and includes it in teardown; **`postToParent`** now accepts structured-cloneable payloads (e.g. `Blob`s).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8e81b0d9a9e8130fb6ccc51c54c51c2a347a757. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->