### PR TITLE
Fall back to `window.__wavedashSdkConfig` when the URL has no `?sdkconfig=`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1633,12 +1633,15 @@ export function setupWavedashSDK(): WavedashSDK {
   const existing = window.Wavedash;
   if (existing) return existing;
 
-  const raw = new URLSearchParams(window.location.search).get(
-    UrlParams.SdkConfig
-  );
+  // `wavedash dev` inlines the config as a global instead of the query
+  // param, keeping the localhost URL clean.
+  const raw =
+    new URLSearchParams(window.location.search).get(UrlParams.SdkConfig) ??
+    (window as { __wavedashSdkConfig?: string }).__wavedashSdkConfig;
+
   if (!raw) {
     throw new Error(
-      `Wavedash SDK: missing ?${UrlParams.SdkConfig}= query param on the iframe URL.`
+      `Wavedash SDK: missing ?${UrlParams.SdkConfig}= query param (or __wavedashSdkConfig global) on the page.`
     );
   }
 


### PR DESCRIPTION
Companion to wvdsh/cli#35: the rewritten `wavedash dev` local server delivers SDKConfig in a port-suffixed `wd_sdkconfig_<port>` cookie instead of the query param, so the game URL is just `http://localhost:PORT/` instead of carrying the full JSON blob.

`setupWavedashSDK()` reads the URL param first and only falls back to the cookie, so prod play iframes and older CLI versions are unaffected. Port-suffixed because cookies are host-scoped and multiple dev servers run on one localhost.

Verified live through the full dev handoff (clean URL, SDK boots from the cookie, anonymous + signed-in flows).

⚠ The cli branch's dev server depends on this being published to npm (jsdelivr `@latest`) — merge + release this before cutting a CLI build from wvdsh/cli#35.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only affects how the initial SDK JSON is sourced; production paths that still pass `?sdkconfig=` behave the same.
> 
> **Overview**
> **`setupWavedashSDK()`** can now bootstrap without `?sdkconfig=` on the URL: it still reads **`UrlParams.SdkConfig`** from the query string first, then falls back to a **`window.__wavedashSdkConfig`** JSON string (for **`wavedash dev`** so localhost URLs stay clean).
> 
> The missing-config error text was updated to mention both sources. Parsing and the rest of init are unchanged when a config string is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21178cca293029fb1261d0e28e0f9a73b533ca2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->