### PR TITLE
Paid Content Functions now standardized

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1332,7 +1332,7 @@ class WavedashSDK extends EventTarget {
    * doesn't actually unlock anything. Pair with triggerPaywall() to drive
    * in-game UI.
    */
-  async isEntitled_EXPERIMENTAL(
+  async isEntitled(
     contentId: string
   ): Promise<WavedashResponse<boolean>> {
     return this.apiCall(
@@ -1342,15 +1342,25 @@ class WavedashSDK extends EventTarget {
       contentId
     );
   }
+  // Kept for backwards compatibility
+  async isEntitled_EXPERIMENTAL(
+    contentId: string
+  ): Promise<WavedashResponse<boolean>> {
+    return this.isEntitled(contentId);
+  }
 
   /**
    * Returns the full list of paid-content IDs the player owns for this game.
    * Reads the `entitlements` claim from the gameplay JWT — this is a UX hint,
-   * not a security check (see {@link isEntitled_EXPERIMENTAL}). Useful
+   * not a security check (see {@link isEntitled}). Useful
    * for access gating multiple items at once without a call per content ID.
    */
-  async getEntitlements_EXPERIMENTAL(): Promise<WavedashResponse<string[]>> {
+  async getEntitlements(): Promise<WavedashResponse<string[]>> {
     return this.apiCall(this.paidContentManager, "getEntitlements", []);
+  }
+  // Kept for backwards compatibility
+  async getEntitlements_EXPERIMENTAL(): Promise<WavedashResponse<string[]>> {
+    return this.getEntitlements();
   }
 
   /**
@@ -1361,7 +1371,7 @@ class WavedashSDK extends EventTarget {
    * subsequent resource fetch is authenticated with the new purchase, and isEntitled
    * will return true if the purchase was successful.
    */
-  async triggerPaywall_EXPERIMENTAL(
+  async triggerPaywall(
     contentIdentifier: string
   ): Promise<WavedashResponse<boolean>> {
     return this.apiCall(
@@ -1370,6 +1380,12 @@ class WavedashSDK extends EventTarget {
       [["contentIdentifier", vString]],
       contentIdentifier
     );
+  }
+  // Kept for backwards compatibility
+  async triggerPaywall_EXPERIMENTAL(
+    contentIdentifier: string
+  ): Promise<WavedashResponse<boolean>> {
+    return this.triggerPaywall(contentIdentifier);
   }
 
   // ==============================


### PR DESCRIPTION
Remove EXPERIMENTAL suffix, keep around for backwards compatibility

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure API rename with delegation wrappers; no changes to entitlement or paywall implementation logic.
> 
> **Overview**
> Promotes the paid-content SDK surface from experimental names to stable **`isEntitled`**, **`getEntitlements`**, and **`triggerPaywall`** on `WavedashSDK` in `src/index.ts`. Behavior is unchanged—the new methods still delegate to `paidContentManager` via the same `apiCall` paths as before.
> 
> The previous `*_EXPERIMENTAL` methods remain as thin forwards to the new names for backwards compatibility. JSDoc for `getEntitlements` now links to **`isEntitled`** instead of the experimental symbol.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f31f8c737d91e61a678af0df354dc898c439c5ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->