### PR TITLE
Use contentIdentifier across the board instead of contentId

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1333,27 +1333,27 @@ class WavedashSDK extends EventTarget {
    * in-game UI.
    */
   async isEntitled(
-    contentId: string
+    contentIdentifier: string
   ): Promise<WavedashResponse<boolean>> {
     return this.apiCall(
       this.paidContentManager,
       "isEntitled",
-      [["contentId", vString]],
-      contentId
+      [["contentIdentifier", vString]],
+      contentIdentifier
     );
   }
   // Kept for backwards compatibility
   async isEntitled_EXPERIMENTAL(
-    contentId: string
+    contentIdentifier: string
   ): Promise<WavedashResponse<boolean>> {
-    return this.isEntitled(contentId);
+    return this.isEntitled(contentIdentifier);
   }
 
   /**
-   * Returns the full list of paid-content IDs the player owns for this game.
+   * Returns the full list of paid-content identifiers the player owns for this game.
    * Reads the `entitlements` claim from the gameplay JWT — this is a UX hint,
    * not a security check (see {@link isEntitled}). Useful
-   * for access gating multiple items at once without a call per content ID.
+   * for access gating multiple items at once without a call per content identifier.
    */
   async getEntitlements(): Promise<WavedashResponse<string[]>> {
     return this.apiCall(this.paidContentManager, "getEntitlements", []);

--- a/src/services/paidContent.ts
+++ b/src/services/paidContent.ts
@@ -41,9 +41,9 @@ export class PaidContentManager extends WavedashManager {
   private paywallOpen = false;
   private restorePointerLock: (() => void) | undefined;
 
-  async isEntitled(contentId: string): Promise<boolean> {
+  async isEntitled(contentIdentifier: string): Promise<boolean> {
     const jwt = await this.sdk.ensureGameplayJwt();
-    return readEntitlementsFromJwt(jwt).includes(contentId);
+    return readEntitlementsFromJwt(jwt).includes(contentIdentifier);
   }
 
   async getEntitlements(): Promise<string[]> {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Renaming the validated argument for `isEntitled` can break engine bridges or callers that still pass `contentId` by name; behavior is unchanged if the string value is correct.
> 
> **Overview**
> Renames the paid-content entitlement API from **`contentId`** to **`contentIdentifier`** so it matches **`triggerPaywall`** and the rest of the SDK vocabulary.
> 
> **`Wavedash.isEntitled`** (and **`isEntitled_EXPERIMENTAL`**) now take **`contentIdentifier`**, and the **`apiCall`** validation spec uses that name instead of **`contentId`**. **`PaidContentManager.isEntitled`** compares the argument against JWT **`ents`** the same way as before. JSDoc for **`getEntitlements`** is updated to say “identifiers” instead of “IDs.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ea5d29d7eafddf426a97c79e485ff84ae278739. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->