### PR TITLE
Disable parent-required iframe SDK calls outside a parent frame

### DIFF
--- a/src/services/audio.ts
+++ b/src/services/audio.ts
@@ -2,6 +2,7 @@ import { IFRAME_MESSAGE_TYPE } from "@wvdsh/api";
 import { WavedashEvents } from "../events";
 import { type WavedashSDK } from "../index";
 import type { MuteChangedPayload } from "../types";
+import { hasParentContext } from "../utils/parentContext";
 import { WavedashManager } from "./manager";
 
 /**
@@ -54,6 +55,8 @@ export class AudioManager extends WavedashManager {
    * MUTE_CHANGED broadcast, so `isMuted()` updates independently of this result.
    */
   async requestMute(muted: boolean): Promise<boolean> {
+    // Mute is owned by the parent UI; disabled outside a Wavedash parent frame.
+    if (!hasParentContext()) return false;
     const response = await this.sdk.iframeMessenger.requestFromParent(
       IFRAME_MESSAGE_TYPE.SET_MUTE,
       { muted }
@@ -67,6 +70,7 @@ export class AudioManager extends WavedashManager {
    * host applied the change.
    */
   async toggleMute(): Promise<boolean> {
+    if (!hasParentContext()) return false;
     const response = await this.sdk.iframeMessenger.requestFromParent(
       IFRAME_MESSAGE_TYPE.TOGGLE_MUTE
     );

--- a/src/services/fullscreen.ts
+++ b/src/services/fullscreen.ts
@@ -2,6 +2,7 @@ import { IFRAME_MESSAGE_TYPE } from "@wvdsh/api";
 import type { WavedashSDK } from "../index";
 import { WavedashEvents } from "../events";
 import type { FullscreenChangedPayload } from "../types";
+import { hasParentContext } from "../utils/parentContext";
 import { WavedashManager } from "./manager";
 
 /**
@@ -29,6 +30,10 @@ export class FullscreenManager extends WavedashManager {
 
   constructor(sdk: WavedashSDK) {
     super(sdk);
+    // Fullscreen is owned by the parent. Outside a Wavedash parent frame there
+    // is no host to drive it, so we leave the page's native fullscreen alone
+    // and skip the compat shims that would otherwise reroute it to nowhere.
+    if (!hasParentContext()) return;
     this.sdk.iframeMessenger.addEventListener(
       IFRAME_MESSAGE_TYPE.FULLSCREEN_CHANGED,
       (data) => {
@@ -52,6 +57,7 @@ export class FullscreenManager extends WavedashManager {
    * (e.g. browser rejected for lack of user activation).
    */
   async requestFullscreen(fullscreen: boolean): Promise<boolean> {
+    if (!hasParentContext()) return false;
     const response = await this.sdk.iframeMessenger.requestFromParent(
       IFRAME_MESSAGE_TYPE.SET_FULLSCREEN,
       { fullscreen }
@@ -60,6 +66,7 @@ export class FullscreenManager extends WavedashManager {
   }
 
   async toggleFullscreen(): Promise<boolean> {
+    if (!hasParentContext()) return false;
     const response = await this.sdk.iframeMessenger.requestFromParent(
       IFRAME_MESSAGE_TYPE.TOGGLE_FULLSCREEN
     );

--- a/src/utils/iframeMessenger.ts
+++ b/src/utils/iframeMessenger.ts
@@ -7,6 +7,7 @@
 
 import { IFRAME_MESSAGE_TYPE, IFrameEventPayloadMap } from "@wvdsh/api";
 import { getParentOrigin } from "./parentOrigin";
+import { hasParentContext } from "./parentContext";
 
 const RESPONSE_TIMEOUT_MS = 15_000;
 
@@ -97,9 +98,12 @@ export class IFrameMessenger {
     requestType: (typeof IFRAME_MESSAGE_TYPE)[keyof typeof IFRAME_MESSAGE_TYPE],
     data: Record<string, string | number | boolean>
   ): boolean {
-    const parentOrigin = getParentOrigin();
-    if (typeof window === "undefined" || !parentOrigin) return false;
-    window.parent.postMessage({ type: requestType, ...data }, parentOrigin);
+    // Parent-owned feature: no-op when running outside a Wavedash parent frame.
+    if (!hasParentContext()) return false;
+    window.parent.postMessage(
+      { type: requestType, ...data },
+      getParentOrigin()
+    );
     return true;
   }
 
@@ -109,11 +113,17 @@ export class IFrameMessenger {
     timeoutMs: number = RESPONSE_TIMEOUT_MS
   ): Promise<IFrameEventPayloadMap[T]> {
     return new Promise((resolve, reject) => {
-      const parentOrigin = getParentOrigin();
-      if (typeof window === "undefined" || !parentOrigin) {
-        reject(new Error("Parent origin not found"));
+      // Parent-owned request: reject fast (rather than waiting out the timeout)
+      // when running outside a Wavedash parent frame, since nobody can answer.
+      if (!hasParentContext()) {
+        reject(
+          new Error(
+            `${requestType} is unavailable: no Wavedash parent frame to handle the request`
+          )
+        );
         return;
       }
+      const parentOrigin = getParentOrigin();
 
       const requestId = `${requestType}_${++this.requestIdCounter}_${Date.now()}`;
 

--- a/src/utils/parentContext.ts
+++ b/src/utils/parentContext.ts
@@ -1,0 +1,20 @@
+/**
+ * Whether the SDK is running embedded in a Wavedash parent frame.
+ *
+ * A whole class of SDK features — fullscreen, mute, the overlay, the paywall —
+ * is owned by the parent (mainsite) and driven over postMessage. When the game
+ * runs outside a parent frame (top-level standalone, `wavedash dev`, or with no
+ * parent origin configured) there is nobody to answer those messages, so the
+ * calls are disabled rather than left to hang until they time out.
+ *
+ * `window.parent === window` is only true at the top level, i.e. when we are
+ * not inside an iframe. We additionally require a configured parent origin
+ * since every postMessage to the parent needs one to target.
+ */
+import { getParentOrigin } from "./parentOrigin";
+
+export function hasParentContext(): boolean {
+  if (typeof window === "undefined") return false;
+  if (window.parent === window) return false;
+  return getParentOrigin() !== "";
+}


### PR DESCRIPTION
Fullscreen, mute, and other parent-owned features are driven over `postMessage` to the Wavedash parent frame. When the game runs outside a parent — top-level standalone, `wavedash dev`, or with no parent origin configured — there's nobody to answer those messages: requests hang until they time out, and the fullscreen compat shims actively break the page's native fullscreen by rerouting `requestFullscreen` to a parent that isn't there.

This adds a shared `hasParentContext()` helper (`window.parent !== window` + a configured parent origin) and gates parent-bound traffic on it:

- `IFrameMessenger.postToParent` no-ops, and `requestFromParent` rejects immediately instead of waiting out the timeout — so every parent-required call (fullscreen, mute, paywall, invite link, device fingerprint, lobby/loading pushes) is disabled in one place.
- `FullscreenManager` skips the `FULLSCREEN_CHANGED` listener and compat shims when there's no parent, leaving the page's native fullscreen untouched.
- The boolean-returning request methods (`requestFullscreen`/`toggleFullscreen`, `requestMute`/`toggleMute`) short-circuit to `false` so their documented contract is preserved rather than rejecting.

Note: `npm run build`'s DTS step fails on a pre-existing `src/services/lobby.ts:415` type error unrelated to this change (present on the base branch); the JS build passes.