### PR TITLE
WVDSH-1588: disable parent-required SDK calls in standalone (wavedash dev)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1544,6 +1544,10 @@ class WavedashSDK extends EventTarget {
       const refreshQuery = new URLSearchParams({
         [UrlParams.Caller]: PlayRouteCaller.Wavedash
       });
+      // A forced refresh follows an event that just changed claims (e.g. a
+      // `wavedash dev` purchase), so tell the dev server to skip its cached JWT
+      // and re-mint. The prod play worker never caches, so it ignores this.
+      if (forceRefresh) refreshQuery.set("fresh", "1");
       const refreshPath = `/auth/refresh?${refreshQuery.toString()}`;
       const response = await fetch(refreshPath, {
         method: "POST",

--- a/src/services/audio.ts
+++ b/src/services/audio.ts
@@ -2,6 +2,8 @@ import { IFRAME_MESSAGE_TYPE } from "@wvdsh/api";
 import { WavedashEvents } from "../events";
 import { type WavedashSDK } from "../index";
 import type { MuteChangedPayload } from "../types";
+import { logger } from "../utils/logger";
+import { hasParentFrame } from "../utils/parentOrigin";
 import { WavedashManager } from "./manager";
 
 /**
@@ -54,6 +56,12 @@ export class AudioManager extends WavedashManager {
    * MUTE_CHANGED broadcast, so `isMuted()` updates independently of this result.
    */
   async requestMute(muted: boolean): Promise<boolean> {
+    if (!hasParentFrame()) {
+      logger.debug(
+        "requestMute() is disabled outside a Wavedash parent frame (e.g. `wavedash dev`)"
+      );
+      return false;
+    }
     const response = await this.sdk.iframeMessenger.requestFromParent(
       IFRAME_MESSAGE_TYPE.SET_MUTE,
       { muted }
@@ -67,6 +75,12 @@ export class AudioManager extends WavedashManager {
    * host applied the change.
    */
   async toggleMute(): Promise<boolean> {
+    if (!hasParentFrame()) {
+      logger.debug(
+        "toggleMute() is disabled outside a Wavedash parent frame (e.g. `wavedash dev`)"
+      );
+      return false;
+    }
     const response = await this.sdk.iframeMessenger.requestFromParent(
       IFRAME_MESSAGE_TYPE.TOGGLE_MUTE
     );

--- a/src/services/fullscreen.ts
+++ b/src/services/fullscreen.ts
@@ -2,6 +2,8 @@ import { IFRAME_MESSAGE_TYPE } from "@wvdsh/api";
 import type { WavedashSDK } from "../index";
 import { WavedashEvents } from "../events";
 import type { FullscreenChangedPayload } from "../types";
+import { logger } from "../utils/logger";
+import { hasParentFrame } from "../utils/parentOrigin";
 import { WavedashManager } from "./manager";
 
 /**
@@ -29,6 +31,9 @@ export class FullscreenManager extends WavedashManager {
 
   constructor(sdk: WavedashSDK) {
     super(sdk);
+    // Standalone: no host to mirror or ask, and top-level pages can fullscreen
+    // themselves — so leave the native API unshimmed.
+    if (!hasParentFrame()) return;
     this.sdk.iframeMessenger.addEventListener(
       IFRAME_MESSAGE_TYPE.FULLSCREEN_CHANGED,
       (data) => {
@@ -52,6 +57,12 @@ export class FullscreenManager extends WavedashManager {
    * (e.g. browser rejected for lack of user activation).
    */
   async requestFullscreen(fullscreen: boolean): Promise<boolean> {
+    if (!hasParentFrame()) {
+      logger.debug(
+        "requestFullscreen() is disabled outside a Wavedash parent frame (e.g. `wavedash dev`)"
+      );
+      return false;
+    }
     const response = await this.sdk.iframeMessenger.requestFromParent(
       IFRAME_MESSAGE_TYPE.SET_FULLSCREEN,
       { fullscreen }
@@ -60,6 +71,12 @@ export class FullscreenManager extends WavedashManager {
   }
 
   async toggleFullscreen(): Promise<boolean> {
+    if (!hasParentFrame()) {
+      logger.debug(
+        "toggleFullscreen() is disabled outside a Wavedash parent frame (e.g. `wavedash dev`)"
+      );
+      return false;
+    }
     const response = await this.sdk.iframeMessenger.requestFromParent(
       IFRAME_MESSAGE_TYPE.TOGGLE_FULLSCREEN
     );

--- a/src/services/heartbeat.ts
+++ b/src/services/heartbeat.ts
@@ -17,6 +17,7 @@ import type { ConnectionState } from "convex/browser";
 import type { BackendConnectionPayload } from "../types";
 import { WavedashManager } from "./manager";
 import { logger } from "../utils/logger";
+import { hasParentFrame } from "../utils/parentOrigin";
 import type { WavedashSDK } from "../index";
 
 // Capture so we see input regardless of which descendant handles it; passive
@@ -81,13 +82,16 @@ export class HeartbeatManager extends WavedashManager {
       this.pollGamepads();
     }, this.GAMEPAD_POLL_INTERVAL_MS);
 
-    this.deviceFingerprintReady = this.sdk.iframeMessenger
-      .requestFromParent(IFRAME_MESSAGE_TYPE.GET_DEVICE_FINGERPRINT)
-      .then((fingerprint) => {
-        this.deviceFingerprint = fingerprint;
-      })
-      // Required catch handler so this.deviceFingerprintReady always resolves
-      .catch(() => {});
+    // No parent to ask in standalone — leave the fingerprint undefined.
+    this.deviceFingerprintReady = !hasParentFrame()
+      ? Promise.resolve()
+      : this.sdk.iframeMessenger
+          .requestFromParent(IFRAME_MESSAGE_TYPE.GET_DEVICE_FINGERPRINT)
+          .then((fingerprint) => {
+            this.deviceFingerprint = fingerprint;
+          })
+          // Keep deviceFingerprintReady resolvable on parent error.
+          .catch(() => {});
 
     // Don't .start() here, loadComplete() will trigger the first call to start()
   }

--- a/src/services/lobby.ts
+++ b/src/services/lobby.ts
@@ -30,6 +30,7 @@ import type { WavedashSDK } from "../index";
 import { api, IFRAME_MESSAGE_TYPE, SDKUser } from "@wvdsh/api";
 import { WavedashManager } from "./manager";
 import { logger } from "../utils/logger";
+import { hasParentFrame } from "../utils/parentOrigin";
 
 export class LobbyManager extends WavedashManager {
   // Track current lobby state
@@ -236,6 +237,13 @@ export class LobbyManager extends WavedashManager {
   async getLobbyInviteLink(copyToClipboard: boolean = false): Promise<string> {
     if (!this.lobbyId) {
       throw new Error("User is not in a lobby");
+    }
+    // The invite URL is minted by the host page; fail clearly rather than time
+    // out waiting on a reply that never comes.
+    if (!hasParentFrame()) {
+      throw new Error(
+        "Lobby invite links are not available outside a Wavedash parent frame (e.g. `wavedash dev`)"
+      );
     }
     const inviteLink = await this.sdk.iframeMessenger.requestFromParent(
       IFRAME_MESSAGE_TYPE.GET_LOBBY_INVITE_LINK,

--- a/src/services/overlay.ts
+++ b/src/services/overlay.ts
@@ -1,6 +1,7 @@
 import { IFRAME_MESSAGE_TYPE } from "@wvdsh/api";
 import { type WavedashSDK } from "../index";
 import { takeFocus } from "../utils/focus";
+import { hasParentFrame } from "../utils/parentOrigin";
 import { suspendPointerLock } from "../utils/pointerLock";
 import { WavedashManager } from "./manager";
 
@@ -21,6 +22,10 @@ export class OverlayManager extends WavedashManager {
 
   constructor(sdk: WavedashSDK) {
     super(sdk);
+
+    // No host owns an overlay in standalone — skip the listeners and the
+    // Shift+Tab hijack so native tab behavior stays intact.
+    if (!hasParentFrame()) return;
 
     this.sdk.iframeMessenger.addEventListener(
       IFRAME_MESSAGE_TYPE.TAKE_FOCUS,

--- a/src/services/paidContent.ts
+++ b/src/services/paidContent.ts
@@ -1,6 +1,8 @@
-import { IFRAME_MESSAGE_TYPE } from "@wvdsh/api";
+import { api, IFRAME_MESSAGE_TYPE } from "@wvdsh/api";
 import { WavedashManager } from "./manager";
 import { logger } from "../utils/logger";
+import { showDevPaywall } from "../utils/devPaywall";
+import { hasParentFrame } from "../utils/parentOrigin";
 import { suspendPointerLock } from "../utils/pointerLock";
 
 const PAYWALL_TIMEOUT_MS = 10 * 60 * 1000;
@@ -58,13 +60,34 @@ export class PaidContentManager extends WavedashManager {
 
     // Don't let the game open a second paywall over an in-progress one.
     if (this.paywallOpen) {
-      throw new Error('Paywall already in progress');
+      throw new Error("Paywall already in progress");
     }
     this.paywallOpen = true;
 
     // Keep the cursor free while the modal is open
     // Restored once the parent responds (or on destroy).
     this.restorePointerLock = suspendPointerLock();
+
+    // Standalone: imitate the host paywall in-page, then grant + refresh so the
+    // end state matches a real purchase (entitlement in the JWT, persisted).
+    if (!hasParentFrame()) {
+      let purchased: boolean;
+      try {
+        purchased = await showDevPaywall(contentIdentifier);
+      } finally {
+        this.restorePointerLock?.();
+        this.restorePointerLock = undefined;
+        this.paywallOpen = false;
+      }
+      if (!purchased) return false;
+      // Grant via the gameplay JWT (sandbox-gated server-side), then refresh so
+      // the new entitlement lands in the JWT `ents`.
+      await this.sdk.convexClient.mutation(api.sdk.paidContent.mockPurchase, {
+        contentIdentifier
+      });
+      await this.sdk.ensureGameplayJwt(true);
+      return true;
+    }
 
     let response;
     try {

--- a/src/utils/devPaywall.ts
+++ b/src/utils/devPaywall.ts
@@ -1,0 +1,93 @@
+// In-page stand-in for the host paywall, shown only in standalone `wavedash
+// dev`. Lets a developer drive both branches of their purchase flow with no
+// real payment; the caller persists a confirmed purchase server-side.
+
+const Z_INDEX = 2147483647;
+
+/** Resolves true on simulated purchase, false on cancel (or no DOM). */
+export function showDevPaywall(contentIdentifier: string): Promise<boolean> {
+  if (typeof document === "undefined") return Promise.resolve(false);
+
+  return new Promise<boolean>((resolve) => {
+    const overlay = document.createElement("div");
+    overlay.style.cssText =
+      "position:fixed;inset:0;z-index:" +
+      Z_INDEX +
+      ";display:flex;align-items:center;justify-content:center;" +
+      "background:rgba(8,10,18,0.72);font:14px ui-sans-serif,system-ui,sans-serif;color:#e2e8f0";
+
+    const card = document.createElement("div");
+    card.style.cssText =
+      "max-width:420px;width:calc(100% - 48px);background:#11151f;border:1px solid #2a3344;" +
+      "border-radius:12px;padding:24px;box-shadow:0 20px 60px rgba(0,0,0,0.5);box-sizing:border-box";
+
+    const badge = document.createElement("p");
+    badge.textContent = "wavedash dev — simulated purchase";
+    badge.style.cssText =
+      "margin:0 0 12px;font-size:11px;letter-spacing:0.08em;text-transform:uppercase;color:#7c8aa5";
+
+    const title = document.createElement("p");
+    title.textContent = "Unlock paid content?";
+    title.style.cssText =
+      "margin:0 0 8px;font-size:18px;font-weight:600;color:#f1f5f9";
+
+    const body = document.createElement("p");
+    body.style.cssText = "margin:0 0 20px;line-height:1.5;color:#cbd5e1";
+    body.append(
+      document.createTextNode("This game is requesting purchase of “")
+    );
+    const id = document.createElement("code");
+    id.textContent = contentIdentifier;
+    id.style.cssText =
+      "background:#1c2433;border-radius:4px;padding:1px 6px;color:#93c5fd";
+    body.append(
+      id,
+      document.createTextNode(
+        "”. No real payment happens in dev — simulate the outcome to test your flow."
+      )
+    );
+
+    const buttons = document.createElement("div");
+    buttons.style.cssText = "display:flex;gap:12px;justify-content:flex-end";
+
+    const baseBtn =
+      "border-radius:8px;padding:9px 18px;font-size:14px;font-weight:600;cursor:pointer;border:1px solid transparent";
+    const cancel = document.createElement("button");
+    cancel.type = "button";
+    cancel.textContent = "Cancel";
+    cancel.style.cssText =
+      baseBtn + ";background:transparent;border-color:#374151;color:#cbd5e1";
+    const buy = document.createElement("button");
+    buy.type = "button";
+    buy.textContent = "Simulate purchase";
+    buy.style.cssText = baseBtn + ";background:#2563eb;color:#fff";
+
+    buttons.append(cancel, buy);
+    card.append(badge, title, body, buttons);
+    overlay.append(card);
+
+    let settled = false;
+    const finish = (purchased: boolean): void => {
+      if (settled) return;
+      settled = true;
+      document.removeEventListener("keydown", onKeyDown, true);
+      overlay.remove();
+      resolve(purchased);
+    };
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        finish(false);
+      }
+    };
+
+    cancel.addEventListener("click", () => finish(false));
+    buy.addEventListener("click", () => finish(true));
+    overlay.addEventListener("click", (event) => {
+      if (event.target === overlay) finish(false);
+    });
+    document.addEventListener("keydown", onKeyDown, true);
+
+    document.body.append(overlay);
+  });
+}

--- a/src/utils/parentOrigin.ts
+++ b/src/utils/parentOrigin.ts
@@ -14,3 +14,13 @@ export function setParentOrigin(origin: string): void {
 export function getParentOrigin(): string {
   return _parentOrigin;
 }
+
+/**
+ * False in standalone contexts like `wavedash dev`, where the game runs
+ * top-level and SDKConfig.parentOrigin is "". Parent-required calls gate on
+ * this so they fail fast or imitate locally instead of hanging on a reply that
+ * never arrives.
+ */
+export function hasParentFrame(): boolean {
+  return _parentOrigin !== "";
+}


### PR DESCRIPTION
## What
Disables sdk-js calls that require a parent/iframe context when the game runs standalone (top-level) under `wavedash dev`, where `SDKConfig.parentOrigin` is `""`. Previously these rejected with **"Parent origin not found"** (reported `TOGGLE_FULLSCREEN`/`SET_FULLSCREEN`, plus mute, overlay, paywall, lobby invites, device fingerprint).

## How
Central `hasParentFrame()` helper (`parentOrigin !== ""`). Each parent-required call gates on it:
- **fullscreen / mute** → resolve `false` (debug log); fullscreen compat shims are **skipped** so native top-level fullscreen still works
- **overlay (Shift+Tab) / device fingerprint** → no-op
- **lobby invite** → throws a clear "not available outside a Wavedash parent frame"
- **paywall** → imitates the host paywall in-page (`devPaywall.ts`); on a confirmed purchase it grants via the gameplay-JWT-authed `api.sdk.paidContent.mockPurchase` (sandbox-gated server-side), then force-refreshes the JWT so `isEntitled`/`getEntitlements` reflect it and it persists across reloads. The forced refresh sends `?fresh=1` so the dev server re-mints from the backend instead of serving a cached token.

## Testing
Verified live through the real `wavedash dev` CLI: every guard returns `false`/no-op, all paywall branches (cancel/esc/buy/already-owned/unconfigured) behave correctly, a simulated purchase records a real `userPaidContent` row reflected in `isEntitled`/`getEntitlements`, and the entitlement survives a fresh reload. See the wvdsh and cli PRs for the backend + dev-server halves.

Linear: WVDSH-1588

🤖 Generated with [Claude Code](https://claude.com/claude-code)
