### PR TITLE
fix: return absolute avatar URLs from SDK user objects (WVDSH-1716)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import { PaidContentManager } from "./services/paidContent";
 import { StatsManager } from "./services/stats";
 import { UGCManager } from "./services/ugc";
 import type { WavedashEventMap } from "./types";
+import { getAvatarUrl } from "./utils/cdn";
 import { IFrameMessenger } from "./utils/iframeMessenger";
 import { LOG_LEVEL, logger } from "./utils/logger";
 import { SwMessenger } from "./utils/swMessenger";
@@ -465,8 +466,15 @@ class WavedashSDK extends EventTarget {
   // User methods
   // ============
 
+  /**
+   * The current user. `avatarUrl` is an absolute URL ready for `<img src>` etc.;
+   * use `getUserAvatarUrl(userId, size)` for a sized/transformed avatar.
+   */
   getUser(): SDKUser {
-    return this.formatResponse(this.wavedashUser);
+    return this.formatResponse({
+      ...this.wavedashUser,
+      avatarUrl: getAvatarUrl(this.wavedashUser.avatarUrl, this.uploadsHost)
+    });
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -466,10 +466,6 @@ class WavedashSDK extends EventTarget {
   // User methods
   // ============
 
-  /**
-   * The current user. `avatarUrl` is an absolute URL ready for `<img src>` etc.;
-   * use `getUserAvatarUrl(userId, size)` for a sized/transformed avatar.
-   */
   getUser(): SDKUser {
     return this.formatResponse({
       ...this.wavedashUser,

--- a/src/services/friends.ts
+++ b/src/services/friends.ts
@@ -7,7 +7,7 @@
 import type { Friend, Id } from "../types";
 import type { WavedashSDK } from "../index";
 import { api } from "@wvdsh/api";
-import { getCdnImageUrl } from "../utils/cdn";
+import { getAvatarUrl, getCdnImageUrl } from "../utils/cdn";
 import { AvatarSize } from "../constants";
 import { WavedashManager } from "./manager";
 
@@ -78,8 +78,13 @@ export class FriendsManager extends WavedashManager {
       api.sdk.friends.listFriends,
       {}
     );
+    // Cache the raw r2Keys first so getUserAvatarUrl() can still size them,
+    // then hand the game absolute avatar URLs.
     this.cacheUsers(friends);
-    return friends;
+    return friends.map((friend) => ({
+      ...friend,
+      avatarUrl: getAvatarUrl(friend.avatarUrl, this.sdk.uploadsHost)
+    }));
   }
 
   /**

--- a/src/services/friends.ts
+++ b/src/services/friends.ts
@@ -7,7 +7,7 @@
 import type { Friend, Id } from "../types";
 import type { WavedashSDK } from "../index";
 import { api } from "@wvdsh/api";
-import { getAvatarUrl, getCdnImageUrl } from "../utils/cdn";
+import { getAvatarUrl } from "../utils/cdn";
 import { AvatarSize } from "../constants";
 import { WavedashManager } from "./manager";
 
@@ -42,13 +42,7 @@ export class FriendsManager extends WavedashManager {
     if (!user?.avatarR2Key) {
       return null;
     }
-    return getCdnImageUrl(user.avatarR2Key, this.sdk.uploadsHost, {
-      width: size,
-      height: size,
-      fit: "cover",
-      quality: "high",
-      sharpen: 1
-    });
+    return getAvatarUrl(user.avatarR2Key, this.sdk.uploadsHost, size) ?? null;
   }
 
   /**

--- a/src/services/friends.ts
+++ b/src/services/friends.ts
@@ -72,8 +72,7 @@ export class FriendsManager extends WavedashManager {
       api.sdk.friends.listFriends,
       {}
     );
-    // Cache the raw r2Keys first so getUserAvatarUrl() can still size them,
-    // then hand the game absolute avatar URLs.
+    // Cache raw keys before URL-ifying so getUserAvatarUrl() can still size them.
     this.cacheUsers(friends);
     return friends.map((friend) => ({
       ...friend,

--- a/src/services/leaderboards.ts
+++ b/src/services/leaderboards.ts
@@ -14,6 +14,7 @@ import type {
 } from "../types";
 import type { WavedashSDK } from "../index";
 import { api } from "@wvdsh/api";
+import { getAvatarUrl } from "../utils/cdn";
 import { WavedashManager } from "./manager";
 
 export class LeaderboardManager extends WavedashManager {
@@ -66,7 +67,10 @@ export class LeaderboardManager extends WavedashManager {
           ...result.entry,
           userId: this.sdk.wavedashUser.id,
           username: this.sdk.wavedashUser.username,
-          userAvatarUrl: this.sdk.wavedashUser.avatarUrl
+          userAvatarUrl: getAvatarUrl(
+            this.sdk.wavedashUser.avatarUrl,
+            this.sdk.uploadsHost
+          )
         }
       : null;
 
@@ -88,8 +92,12 @@ export class LeaderboardManager extends WavedashManager {
     if (result && result.totalEntries) {
       this.updateCachedTotalEntries(leaderboardId, result.totalEntries);
     }
+    // Cache raw r2Keys for getUserAvatarUrl(), then return absolute avatar URLs.
     this.sdk.friendsManager.cacheLeaderboardPage(result.entries);
-    return result.entries;
+    return result.entries.map((entry) => ({
+      ...entry,
+      userAvatarUrl: getAvatarUrl(entry.userAvatarUrl, this.sdk.uploadsHost)
+    }));
   }
 
   async listLeaderboardEntries(
@@ -105,8 +113,12 @@ export class LeaderboardManager extends WavedashManager {
     if (result && result.totalEntries) {
       this.updateCachedTotalEntries(leaderboardId, result.totalEntries);
     }
+    // Cache raw r2Keys for getUserAvatarUrl(), then return absolute avatar URLs.
     this.sdk.friendsManager.cacheLeaderboardPage(result.entries);
-    return result.entries;
+    return result.entries.map((entry) => ({
+      ...entry,
+      userAvatarUrl: getAvatarUrl(entry.userAvatarUrl, this.sdk.uploadsHost)
+    }));
   }
 
   async uploadLeaderboardScore(
@@ -131,7 +143,10 @@ export class LeaderboardManager extends WavedashManager {
       // User info
       userId: this.sdk.wavedashUser.id,
       username: this.sdk.wavedashUser.username,
-      userAvatarUrl: this.sdk.wavedashUser.avatarUrl
+      userAvatarUrl: getAvatarUrl(
+        this.sdk.wavedashUser.avatarUrl,
+        this.sdk.uploadsHost
+      )
     };
   }
 

--- a/src/services/leaderboards.ts
+++ b/src/services/leaderboards.ts
@@ -92,7 +92,7 @@ export class LeaderboardManager extends WavedashManager {
     if (result && result.totalEntries) {
       this.updateCachedTotalEntries(leaderboardId, result.totalEntries);
     }
-    // Cache raw r2Keys for getUserAvatarUrl(), then return absolute avatar URLs.
+    // Cache raw keys before URL-ifying so getUserAvatarUrl() can still size them.
     this.sdk.friendsManager.cacheLeaderboardPage(result.entries);
     return result.entries.map((entry) => ({
       ...entry,
@@ -113,7 +113,7 @@ export class LeaderboardManager extends WavedashManager {
     if (result && result.totalEntries) {
       this.updateCachedTotalEntries(leaderboardId, result.totalEntries);
     }
-    // Cache raw r2Keys for getUserAvatarUrl(), then return absolute avatar URLs.
+    // Cache raw keys before URL-ifying so getUserAvatarUrl() can still size them.
     this.sdk.friendsManager.cacheLeaderboardPage(result.entries);
     return result.entries.map((entry) => ({
       ...entry,

--- a/src/services/lobby.ts
+++ b/src/services/lobby.ts
@@ -29,6 +29,7 @@ import { WavedashEvents } from "../events";
 import type { WavedashSDK } from "../index";
 import { api, IFRAME_MESSAGE_TYPE, SDKUser } from "@wvdsh/api";
 import { WavedashManager } from "./manager";
+import { getAvatarUrl } from "../utils/cdn";
 import { logger } from "../utils/logger";
 import { hasParentFrame } from "../utils/parentOrigin";
 
@@ -107,7 +108,10 @@ export class LobbyManager extends WavedashManager {
       logger.error("Must be a member of the lobby to access user list");
       return [];
     }
-    return this.lobbyUsers;
+    return this.lobbyUsers.map((user) => ({
+      ...user,
+      userAvatarUrl: getAvatarUrl(user.userAvatarUrl, this.sdk.uploadsHost)
+    }));
   }
 
   getHostId(lobbyId: Id<"lobbies">): Id<"users"> | null {
@@ -522,6 +526,10 @@ export class LobbyManager extends WavedashManager {
           WavedashEvents.LOBBY_USERS_UPDATED,
           {
             ...user,
+            userAvatarUrl: getAvatarUrl(
+              user.userAvatarUrl,
+              this.sdk.uploadsHost
+            ),
             changeType: LobbyUserChangeType.JOINED
           } satisfies LobbyUsersUpdatedPayload
         );
@@ -542,6 +550,10 @@ export class LobbyManager extends WavedashManager {
           WavedashEvents.LOBBY_USERS_UPDATED,
           {
             ...user,
+            userAvatarUrl: getAvatarUrl(
+              user.userAvatarUrl,
+              this.sdk.uploadsHost
+            ),
             isHost: false,
             changeType: LobbyUserChangeType.LEFT
           } satisfies LobbyUsersUpdatedPayload

--- a/src/utils/cdn.ts
+++ b/src/utils/cdn.ts
@@ -1,18 +1,25 @@
+import { AvatarSize } from "../constants";
+
 /**
- * Absolute URL for an avatar stored as an r2Key, so it's directly usable in
- * `<img src>`, canvas/WebGL textures, or fetch. Values that are already absolute
- * URLs pass through unchanged. Unlike `getCdnImageUrl` this applies no resizing —
- * use `getUserAvatarUrl(userId, size)` when you want a sized/transformed avatar.
+ * Absolute, CDN-resized avatar URL for an r2Key. Single source of truth for
+ * building avatar URLs: both `getUserAvatarUrl(userId, size)` and the
+ * `avatarUrl`/`userAvatarUrl` fields on returned user objects go through here, so
+ * every avatar is served resized via `cdn-cgi`. Values that are already absolute
+ * URLs pass through unchanged; an empty value returns `undefined`.
  */
 export function getAvatarUrl(
   r2KeyOrUrl: string | undefined,
-  host: string
+  host: string,
+  size: number = AvatarSize.MEDIUM
 ): string | undefined {
   if (!r2KeyOrUrl) return undefined;
-  if (r2KeyOrUrl.startsWith("http://") || r2KeyOrUrl.startsWith("https://")) {
-    return r2KeyOrUrl;
-  }
-  return `https://${host}/${r2KeyOrUrl}`;
+  return getCdnImageUrl(r2KeyOrUrl, host, {
+    width: size,
+    height: size,
+    fit: "cover",
+    quality: "high",
+    sharpen: 1
+  });
 }
 
 export function getCdnImageUrl(

--- a/src/utils/cdn.ts
+++ b/src/utils/cdn.ts
@@ -1,12 +1,6 @@
 import { AvatarSize } from "../constants";
 
-/**
- * Absolute, CDN-resized avatar URL for an r2Key. Single source of truth for
- * building avatar URLs: both `getUserAvatarUrl(userId, size)` and the
- * `avatarUrl`/`userAvatarUrl` fields on returned user objects go through here, so
- * every avatar is served resized via `cdn-cgi`. Values that are already absolute
- * URLs pass through unchanged; an empty value returns `undefined`.
- */
+/** Single builder for avatar URLs so every avatar is served cdn-cgi resized. */
 export function getAvatarUrl(
   r2KeyOrUrl: string | undefined,
   host: string,

--- a/src/utils/cdn.ts
+++ b/src/utils/cdn.ts
@@ -1,3 +1,20 @@
+/**
+ * Absolute URL for an avatar stored as an r2Key, so it's directly usable in
+ * `<img src>`, canvas/WebGL textures, or fetch. Values that are already absolute
+ * URLs pass through unchanged. Unlike `getCdnImageUrl` this applies no resizing —
+ * use `getUserAvatarUrl(userId, size)` when you want a sized/transformed avatar.
+ */
+export function getAvatarUrl(
+  r2KeyOrUrl: string | undefined,
+  host: string
+): string | undefined {
+  if (!r2KeyOrUrl) return undefined;
+  if (r2KeyOrUrl.startsWith("http://") || r2KeyOrUrl.startsWith("https://")) {
+    return r2KeyOrUrl;
+  }
+  return `https://${host}/${r2KeyOrUrl}`;
+}
+
 export function getCdnImageUrl(
   r2Key: string,
   host: string,


### PR DESCRIPTION
## Problem

A creator reported their avatar showing as "unauthorised" in the playtest area (WVDSH-1716).

Root cause: the user objects the SDK returns to games expose `avatarUrl` / `userAvatarUrl` set to the **raw R2 key** (e.g. `avatars/<user>/<file>.jpg`), not a URL — despite the name. A game doing the natural thing:

```js
img.src = Wavedash.getUser().avatarUrl; // "avatars/…/….jpg"
```

gets a **relative** path, which the browser resolves against the game's own origin → `https://<id>.builds.wavedashcdn.com/avatars/…`. The play worker's auth middleware rejects that path with **401 Unauthorized** → broken "unauthorised" avatar.

The only method that returned a real URL was `getUserAvatarUrl(userId, size)` (the CDN transform URL), which isn't obvious.

## Fix

Make `avatarUrl` / `userAvatarUrl` an **absolute URL** everywhere the SDK hands a user object to the game, so `<img src>` / canvas / fetch just work. `getUserAvatarUrl(userId, size)` is unchanged for sized/transformed avatars.

- `utils/cdn.ts` — `getAvatarUrl(r2KeyOrUrl, host, size?)` is now the **single avatar-URL builder**: it produces a `cdn-cgi` **resized** URL (delegating to `getCdnImageUrl`), passes through anything already absolute, and returns `undefined` for an empty value.
- `getUserAvatarUrl(userId, size)` is now a thin cache-lookup wrapper over `getAvatarUrl` — one code path, so every avatar is served resized.
- Applied at each game-facing boundary: `getUser()`, `listFriends()`, `getLobbyUsers()`, both `LOBBY_USERS_UPDATED` event payloads, and all four leaderboard entry paths. Fields default to `AvatarSize.MEDIUM`, so `friend.avatarUrl === getUserAvatarUrl(friend.userId)`.
- Internal caches keep the **raw key** so `getUserAvatarUrl(userId, size)` sizing still works. The p2p `SDKUser` (id-based, connection setup, never shown to the game) is left as-is.

## Other SDKs

Unity, Godot, and Defold are pure pass-throughs to the JS SDK — they forward these fields and delegate `getUserAvatarUrl` to JS — so they're covered automatically once this ships. No changes needed there.

## Shipping

The SDK is bundled into `play/static/embed.js` and injected as `window.Wavedash`. After this merges: publish `@wvdsh/sdk-js` → rebuild the play embed (`npm run build:embed`) → deploy `play`. `wavedash` only passes SDKConfig and needs no change.

## Notes

- `avatarUrl`/`userAvatarUrl` are served resized (default `AvatarSize.MEDIUM`) via `cdn-cgi`, same as `getUserAvatarUrl`. Use `getUserAvatarUrl(userId, size)` when you want a different size.

## Verification

`typecheck` · `build` (tsup) · `prettier` · `eslint` — all pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized presentation-layer change at SDK return boundaries; caches retain raw keys and auth/data paths are untouched.
> 
> **Overview**
> Fixes broken avatars when games use `avatarUrl` / `userAvatarUrl` directly (e.g. `img.src`), which previously exposed **raw R2 keys** that the browser resolved against the game origin and got **401** from the play worker.
> 
> Adds **`getAvatarUrl`** in `utils/cdn.ts` as the shared builder for **`cdn-cgi` resized** absolute URLs (default `AvatarSize.MEDIUM`), and applies it at every boundary that returns user objects to the game: **`getUser()`**, **`listFriends()`**, **`getLobbyUsers()`**, **`LOBBY_USERS_UPDATED`** payloads, and all leaderboard entry paths. **`getUserAvatarUrl(userId, size)`** now delegates to the same helper.
> 
> Internal **caches still store raw R2 keys** (cached before mapping API responses) so sized lookups keep working. P2P-internal `SDKUser` objects are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70c92e1c2fa5d0cab201794e1d5ec370618abdcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->