### PR TITLE
Add leaderboard metadata

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,26 @@
+# Enforce LF line endings across the team, regardless of each dev's local git config.
+# Text files are auto-detected and normalized to LF in the repo and on checkout.
+* text=auto eol=lf
+
+# Common binary types — never apply line-ending conversion.
+*.png    binary
+*.jpg    binary
+*.jpeg   binary
+*.gif    binary
+*.ico    binary
+*.webp   binary
+*.pdf    binary
+*.zip    binary
+*.gz     binary
+*.tar    binary
+*.7z     binary
+*.mp3    binary
+*.wav    binary
+*.ogg    binary
+*.mp4    binary
+*.mov    binary
+*.woff   binary
+*.woff2  binary
+*.ttf    binary
+*.otf    binary
+*.eot    binary

--- a/src/index.ts
+++ b/src/index.ts
@@ -659,9 +659,24 @@ class WavedashSDK extends EventTarget {
     leaderboardId: Id<"leaderboards">,
     score: number,
     keepBest: boolean,
-    ugcId?: Id<"userGeneratedContent">,
-    metadata?: LeaderboardEntryMetadata
+    ugcId?: Id<"userGeneratedContent"> | null,
+    metadata?: LeaderboardEntryMetadata | null
   ): Promise<WavedashResponse<UpsertedLeaderboardEntry>> {
+    if (typeof metadata === "string") {
+      const raw = metadata;
+      try {
+        metadata = JSON.parse(raw);
+      } catch (error) {
+        const message = `uploadLeaderboardScore: invalid JSON: ${raw}`;
+        logger.error(message, error);
+        return this.formatResponse({
+          success: false,
+          data: null,
+          message
+        });
+      }
+    }
+
     return this.apiCall(
       this.leaderboardManager,
       "uploadLeaderboardScore",
@@ -675,8 +690,8 @@ class WavedashSDK extends EventTarget {
       leaderboardId,
       score,
       keepBest,
-      ugcId,
-      metadata
+      ugcId ?? undefined,
+      metadata ?? undefined
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -659,8 +659,8 @@ class WavedashSDK extends EventTarget {
     leaderboardId: Id<"leaderboards">,
     score: number,
     keepBest: boolean,
-    ugcId?: Id<"userGeneratedContent"> | null,
-    metadata?: LeaderboardEntryMetadata | null
+    ugcId?: Id<"userGeneratedContent">,
+    metadata?: LeaderboardEntryMetadata
   ): Promise<WavedashResponse<UpsertedLeaderboardEntry>> {
     if (typeof metadata === "string") {
       const raw = metadata;

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ import type {
   Leaderboard,
   LeaderboardDisplayType,
   LeaderboardEntries,
+  LeaderboardEntryMetadata,
   LeaderboardSortOrder,
   ListUGCItemsArgs,
   Lobby,
@@ -79,6 +80,7 @@ import {
   vOptional,
   vRecord,
   vString,
+  vStringOrNumberRecord,
   vUint8Array,
   vUnion
 } from "./utils/validation";
@@ -657,7 +659,8 @@ class WavedashSDK extends EventTarget {
     leaderboardId: Id<"leaderboards">,
     score: number,
     keepBest: boolean,
-    ugcId?: Id<"userGeneratedContent">
+    ugcId?: Id<"userGeneratedContent">,
+    metadata?: LeaderboardEntryMetadata
   ): Promise<WavedashResponse<UpsertedLeaderboardEntry>> {
     return this.apiCall(
       this.leaderboardManager,
@@ -666,12 +669,14 @@ class WavedashSDK extends EventTarget {
         ["leaderboardId", vId("leaderboards")],
         ["score", vNumber],
         ["keepBest", vBoolean],
-        ["ugcId", vOptional(vId("userGeneratedContent"))]
+        ["ugcId", vOptional(vId("userGeneratedContent"))],
+        ["metadata", vOptional(vStringOrNumberRecord)]
       ],
       leaderboardId,
       score,
       keepBest,
-      ugcId
+      ugcId,
+      metadata
     );
   }
 

--- a/src/services/leaderboards.ts
+++ b/src/services/leaderboards.ts
@@ -10,6 +10,7 @@ import type {
   LeaderboardDisplayType,
   Leaderboard,
   LeaderboardEntries,
+  LeaderboardEntryMetadata,
   UpsertedLeaderboardEntry
 } from "../types";
 import type { WavedashSDK } from "../index";
@@ -125,11 +126,12 @@ export class LeaderboardManager extends WavedashManager {
     leaderboardId: Id<"leaderboards">,
     score: number,
     keepBest: boolean,
-    ugcId?: Id<"userGeneratedContent">
+    ugcId?: Id<"userGeneratedContent">,
+    metadata?: LeaderboardEntryMetadata
   ): Promise<UpsertedLeaderboardEntry> {
     const result = await this.sdk.convexClient.mutation(
       api.sdk.leaderboards.upsertLeaderboardEntry,
-      { leaderboardId, score, keepBest, ugcId }
+      { leaderboardId, score, keepBest, ugcId, metadata }
     );
     if (result && result.totalEntries) {
       this.updateCachedTotalEntries(leaderboardId, result.totalEntries);

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,9 @@ export type UpsertedLeaderboardEntry = FunctionReturnType<
   submittedScore: number;
   submittedRank: number;
 };
+export type LeaderboardEntryMetadata = NonNullable<
+  FunctionArgs<typeof api.sdk.leaderboards.upsertLeaderboardEntry>["metadata"]
+>;
 
 // Type helper to get event values as a union type
 export type WavedashEvent =

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -76,6 +76,24 @@ export const vRecord: Validator<
   return value as Record<string, string | number | boolean | null>;
 };
 
+export const vStringOrNumberRecord: Validator<
+  Record<string, string | number>
+> = (value, path) => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(
+      `${path}: expected plain object, got ${describeValue(value)}`
+    );
+  }
+  for (const [key, val] of Object.entries(value)) {
+    if (typeof val !== "string" && typeof val !== "number") {
+      throw new Error(
+        `${path}: expected only string or number values, but key "${key}" is ${describeValue(val)}`
+      );
+    }
+  }
+  return value as Record<string, string | number>;
+};
+
 /**
  * Validate a Convex document ID string.
  * Format check only (31-37 char lowercase base32); the actual table binding


### PR DESCRIPTION
Should be backwards compatible with the old function signatures since all instances of metadata are vOptional, although I'd like to test this on staging first if possible?
This should not be merged in before the backend supports these updated signatures.

Updates to the other sdks to support leaderboard metadata will come later, once I finish the godot typing changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wvdsh/sdk-js/pull/157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->