### PR TITLE
coerce null into defaults

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,8 @@ import {
   SDKUser,
   UrlParams,
   PlayRouteCaller,
-  SERVICE_WORKER_MESSAGE_TYPE
+  SERVICE_WORKER_MESSAGE_TYPE,
+  LOBBY_DEFAULTS
 } from "@wvdsh/api";
 import type {
   EngineInstance,
@@ -734,7 +735,7 @@ class WavedashSDK extends EventTarget {
       title,
       description,
       visibility,
-      filePath
+      filePath ?? undefined
     );
   }
 
@@ -1193,7 +1194,7 @@ class WavedashSDK extends EventTarget {
         ["maxPlayers", vOptional(vNumber)]
       ],
       visibility,
-      maxPlayers
+      maxPlayers ?? LOBBY_DEFAULTS.MAX_PLAYERS
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,8 +42,7 @@ import {
   SDKUser,
   UrlParams,
   PlayRouteCaller,
-  SERVICE_WORKER_MESSAGE_TYPE,
-  LOBBY_DEFAULTS
+  SERVICE_WORKER_MESSAGE_TYPE
 } from "@wvdsh/api";
 import type {
   EngineInstance,
@@ -1194,7 +1193,7 @@ class WavedashSDK extends EventTarget {
         ["maxPlayers", vOptional(vNumber)]
       ],
       visibility,
-      maxPlayers ?? LOBBY_DEFAULTS.MAX_PLAYERS
+      maxPlayers ?? undefined
     );
   }
 


### PR DESCRIPTION
fixes bugs in the godot sdk where omitting parameters doesn't use the parameter defaults but instead errors and rejects the call